### PR TITLE
improve build.zig + use v0.14.0 idioms

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           version: 0.14.0
       - name: Build Examples
-        run: zig build
+        run: zig build -Dexample=all
       - name: Run unit tests
         run: zig build test --summary all
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,31 @@ const tardy = b.dependency("tardy", .{
     .optimize = optimize,
 }).module("tardy");
 
-exe.root_module.addImport(tardy);
+exe_mod.addImport("tardy", tardy);
 ```
 
-## Example
+## Building and running example folder
+- NOTE: by default build/install step uses `-Dexample=none` , meaning it wont build any examples
+
+- List available examples
+```sh
+zig build --help
+```
+
+- Build/run a specific example
+```sh
+zig build -Dexample=[nameOfExample]
+```
+```sh
+zig run -Dexample=[nameOfExample]
+```
+
+- Build all examples
+```sh
+zig build -Dexample=all
+```
+
+## TCP Example
 A basic multi-threaded TCP echo server.
 
 ```zig

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const tardy = b.dependency("tardy", .{
 exe_mod.addImport("tardy", tardy);
 ```
 
-## Building and running example folder
+## Building and Running Examples
 - NOTE: by default build/install step uses `-Dexample=none` , meaning it wont build any examples
 
 - List available examples

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ zig build --help
 zig build -Dexample=[nameOfExample]
 ```
 ```sh
-zig run -Dexample=[nameOfExample]
+zig build run -Dexample=[nameOfExample]
 ```
 
 - Build all examples

--- a/build.zig
+++ b/build.zig
@@ -72,7 +72,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    // (zig build and zig run -Dexample= )
+    // (zig build and zig build run -Dexample= )
     build_examples(b, .{
         .run = build_steps.run,
         .install = b.getInstallStep(),
@@ -98,7 +98,7 @@ pub fn build(b: *std.Build) void {
 }
 
 // used for building and running examples
-// usage: zig [build/run] -Dexample=[basic/echo/..]
+// usage: zig [build/build run] -Dexample=[basic/echo/..]
 fn build_examples(
     b: *std.Build,
     steps: struct {

--- a/build.zig
+++ b/build.zig
@@ -59,6 +59,7 @@ pub fn build(b: *std.Build) void {
         .static = b.step("static", "Build tardy as a static lib"),
         .@"test" = b.step("test", "Run all tests"), // TODO
         .test_unit = b.step("test_unit", "Run general unit tests"),
+        .test_fmt = b.step("test_fmt", "Run e2e tests"),
         .test_e2e = b.step("test_e2e", "Run e2e tests"),
     };
 
@@ -101,6 +102,7 @@ pub fn build(b: *std.Build) void {
     // build/run tests
     build_test(b, .{
         .test_unit = build_steps.test_unit,
+        .test_fmt = build_steps.test_fmt,
         .@"test" = build_steps.@"test",
     }, .{
         .tardy_mod = tardy,
@@ -295,6 +297,7 @@ fn build_test(
     b: *std.Build,
     steps: struct {
         test_unit: *std.Build.Step,
+        test_fmt: *std.Build.Step,
         @"test": *std.Build.Step,
     },
     options: struct {
@@ -317,7 +320,14 @@ fn build_test(
 
     steps.test_unit.dependOn(&run_unit_tests.step);
 
-    // TODO: run all tests / is that possible?
+    // zig build fmt
+    // check formatting
+    const run_fmt = b.addFmt(.{ .paths = &.{"."}, .check = true });
+    steps.test_fmt.dependOn(&run_fmt.step);
+
+    // zig build test
+    steps.@"test".dependOn(&run_unit_tests.step);
+    steps.@"test".dependOn(steps.test_fmt);
 }
 
 fn build_test_e2e(

--- a/build.zig
+++ b/build.zig
@@ -55,7 +55,9 @@ pub fn build(b: *std.Build) void {
     };
 
     // Build options passed with `-D` flags.
-    const build_options = .{};
+    const build_options = .{
+        .example = b.option(Example, "example", "example name") orelse .none,
+    };
 
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});

--- a/build.zig
+++ b/build.zig
@@ -166,6 +166,8 @@ fn build_examples(
     // build .all example
     // run wont work for .all example
     if (options.example == .all) {
+        std.log.info("zig build run -Dexample=all will only build examples and will not run them", .{});
+
         inline for (std.meta.fields(Example)) |f| {
             // convert captured field value to field enum
             const field = @as(Example, @enumFromInt(f.value));
@@ -259,7 +261,6 @@ fn build_example_exe(
     steps.install.dependOn(&install_artifact.step);
 
     // Should not run all examples at the same time
-    std.log.info("zig build run -Dexample=all will only build examples and will not runt them", .{});
     if (options.all_examples) {
         return;
     }

--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,37 @@ comptime {
     }
 }
 
+const Example = enum {
+    none,
+    all,
+
+    basic,
+    cat,
+    channel,
+    echo,
+    http,
+    rmdir,
+    shove,
+    stat,
+    stream,
+
+    fn toString(ex: Example) []u8 {
+        const ex_string = switch (ex) {
+            .basic => "basic",
+            .cat => "cat",
+            .channel => "channel",
+            .echo => "echo",
+            .http => "http",
+            .rmdir => "rmdir",
+            .shove => "shove",
+            .stat => "stat",
+            .stream => "stream",
+        };
+
+        return ex_string;
+    }
+};
+
 pub fn build(b: *std.Build) void {
 
     // Top-level steps you can invoke on the command line.

--- a/build.zig
+++ b/build.zig
@@ -62,6 +62,7 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    // create a public tardy module
     const tardy = b.addModule("tardy", .{
         .root_source_file = b.path("src/lib.zig"),
         .target = target,
@@ -90,6 +91,25 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_test.step);
 
     add_test(b, "e2e", target, optimize, tardy);
+}
+
+fn build_example_module(
+    b: *std.Build,
+    options: struct {
+        tardy_mod: *std.Build.Module,
+        target: std.Build.ResolvedTarget,
+        optimize: std.builtin.OptimizeMode,
+    },
+) *std.Build.Module {
+    // create a private example module
+    const example_mod = b.createModule(.{
+        .target = options.target,
+        .optimize = options.optimize,
+    });
+
+    example_mod.addImport("tardy", options.tardy_mod);
+
+    return example_mod;
 }
 
 fn add_example(

--- a/build.zig
+++ b/build.zig
@@ -151,6 +151,11 @@ fn build_example_exe(
     // build
     steps.install.dependOn(&install_artifact.step);
 
+    // Should not run all examples at the same time
+    if (options.example == .all) {
+        return;
+    }
+
     // run
     const run_artifact = b.addRunArtifact(example_exe);
     run_artifact.step.dependOn(&install_artifact.step);

--- a/build.zig
+++ b/build.zig
@@ -109,6 +109,10 @@ fn build_example_module(
 
     example_mod.addImport("tardy", options.tardy_mod);
 
+    if (options.target.result.os.tag == .windows) {
+        example_mod.linkLibC();
+    }
+
     return example_mod;
 }
 

--- a/build.zig
+++ b/build.zig
@@ -50,7 +50,9 @@ const Example = enum {
 pub fn build(b: *std.Build) void {
 
     // Top-level steps you can invoke on the command line.
-    const build_steps = .{};
+    const build_steps = .{
+        .run = b.step("run", "Run a Tardy Program/Example"),
+    };
 
     // Build options passed with `-D` flags.
     const build_options = .{};

--- a/build.zig
+++ b/build.zig
@@ -225,7 +225,6 @@ fn build_example_exe(
     });
 
     const install_artifact = b.addInstallArtifact(example_exe, .{});
-    b.getInstallStep().dependOn(&install_artifact.step);
 
     // depend on build/install step
     steps.install.dependOn(&install_artifact.step);

--- a/build.zig
+++ b/build.zig
@@ -57,9 +57,9 @@ pub fn build(b: *std.Build) void {
     const build_steps = .{
         .run = b.step("run", "Run a Tardy Program/Example"),
         .static = b.step("static", "Build tardy as a static lib"),
-        .@"test" = b.step("test", "Run all tests"), // TODO
+        .@"test" = b.step("test", "Run all tests"),
         .test_unit = b.step("test_unit", "Run general unit tests"),
-        .test_fmt = b.step("test_fmt", "Run e2e tests"),
+        .test_fmt = b.step("test_fmt", "Run formmatter tests"),
         .test_e2e = b.step("test_e2e", "Run e2e tests"),
     };
 
@@ -325,6 +325,7 @@ fn build_test(
     const run_fmt = b.addFmt(.{ .paths = &.{"."}, .check = true });
     steps.test_fmt.dependOn(&run_fmt.step);
 
+    // run all tests
     // zig build test
     steps.@"test".dependOn(&run_unit_tests.step);
     steps.@"test".dependOn(steps.test_fmt);
@@ -369,14 +370,16 @@ fn build_test_e2e(
         .strip = false,
     });
 
-    // TODO: add description
-
+    // build/install e2e test
     const install_artifact = b.addInstallArtifact(exe, .{});
     steps.test_e2e.dependOn(&install_artifact.step);
 
+    // run e2e test
     const run_artifact = b.addRunArtifact(exe);
     run_artifact.step.dependOn(&install_artifact.step);
 
+    // you need to pass a u64 as an arg
+    // zig build test_e2e -- [u64 num]
     if (b.args) |args| run_artifact.addArgs(args);
 
     steps.test_e2e.dependOn(&install_artifact.step);

--- a/build.zig
+++ b/build.zig
@@ -17,6 +17,13 @@ comptime {
 }
 
 pub fn build(b: *std.Build) void {
+
+    // Top-level steps you can invoke on the command line.
+    const build_steps = .{};
+
+    // Build options passed with `-D` flags.
+    const build_options = .{};
+
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 


### PR DESCRIPTION
- added build steps and build options
this will make finding what steps are used and what options are available easier

- you only need zig build and zig build run 
specifiy examples to build/run by using `-Dexample=[nameOfExample]` option

- added static step to build tardy as a standalone lib `zig build static`
- e2e test been ported `zig build test_e2e -Dasync=auto`
-  unit tests been ported `zig build test_unit`
- added formatting checker test `zig build test_fmt`
- `zig build test` will now run unit tests and fmting tests

- decoupled build example module and build example exe functions
- replaced root_module with the new createMod and addImport introduced in v0.14.0
- note: github actions wont compile any examples for os piplines  / can be added via run step `zig build -Dexample=all`