### PR TITLE
fix incorrect alignment panic on aarch64 architectures

### DIFF
--- a/src/frame/asm/aarch64_gen.asm
+++ b/src/frame/asm/aarch64_gen.asm
@@ -1,9 +1,11 @@
+// https://www.wasilzafar.com/pages/series/arm-assembly/arm-assembly-06-stack-subroutines.html
 .global _tardy_swap_frame
-.global tardy_swap_frame 
+.global tardy_swap_frame
 
 _tardy_swap_frame:
 tardy_swap_frame:
-      stp lr, fp, [sp, #-20*8]!
+      // store non-volatile state of current Fibre to its stack
+      stp fp, lr, [sp, #-20*8]!
       stp d8, d9, [sp, #2*8]
       stp d10, d11, [sp, #4*8]
       stp d12, d13, [sp, #6*8]
@@ -14,11 +16,17 @@ tardy_swap_frame:
       stp x25, x26, [sp, #16*8]
       stp x27, x28, [sp, #18*8]
 
+      // Copy the current Stack Pointer into a temporary/volatile register (x9)
       mov x9, sp
+      // Save the old fiber's Stack Pointer into the pointer address held in x0 (*sp)
       str x9, [x0]
+      // Load the new fiber's Stack Pointer from the address held in x1 (*sp) into x9
       ldr x9, [x1]
+      // Overwrite the CPU's Stack Pointer.
+      // The CPU is now executing on the new fiber's stack!
       mov sp, x9
 
+      // load the state of the new fiber into the CPU registers.
       ldp x27, x28, [sp, #18*8]
       ldp x25, x26, [sp, #16*8]
       ldp x23, x24, [sp, #14*8]
@@ -28,6 +36,14 @@ tardy_swap_frame:
       ldp d12, d13, [sp, #6*8]
       ldp d10, d11, [sp, #4*8]
       ldp d8, d9, [sp, #2*8]
-      ldp lr, fp, [sp], #20*8
-      
-      ret
+      ldp fp, lr, [sp], #20*8
+
+      // Pop the return address into x9 (a caller saved temporary register)
+      mov x9, lr
+
+      // Zero out LR so that when the `func` inside EntryFn code starts, it will save
+      // LR=0 to the stack cleanly terminating the DWARF unwinder and preventing it from
+      // trying to capture stack traces outside of the Fibre's stack space.
+      mov lr, xzr
+
+      ret x9

--- a/src/frame/asm/x86_64_sysv.asm
+++ b/src/frame/asm/x86_64_sysv.asm
@@ -3,6 +3,11 @@
 
 _tardy_swap_frame:
 tardy_swap_frame:
+    // save non-volatile callee saved registers
+    // Return Address (RIP) is implicitly pushed onto the stack by the call instruction
+    // that invoked this function making 7 registers
+    // pushq automatically subtracts 8 from the Stack Pointer (%rsp) and writes the
+    // 64-bit register to that memory address
     pushq %rbx
     pushq %rbp
     pushq %r12
@@ -11,13 +16,24 @@ tardy_swap_frame:
     pushq %r15
 
     // swap stacks
+    // Saves the current CPU Stack Pointer %rsp into the 1st arg (%rdi)
+    // of `tardy_swap_frame` **old_sp
     movq %rsp, (%rdi)
+    // load the %rsi address (from the 2nd arg of `tardy_swap_frame` **new_sp) and
+    // overwrites the CPU's Stack Pointer. The CPU is now executing on the new fiber's
+    // stack.
     movq (%rsi), %rsp
 
+    // popq read the 8 bytes at %rsp into the register and then automatically
+    // add 8 to %rsp
     popq %r15
     popq %r14
     popq %r13
     popq %r12
     popq %rbp
     popq %rbx
+
+    // retq pops the final 8 bytes off the stack (which is the Return Address) directly
+    // into the CPU's Instruction Pointer (RIP) and jumps to it to execute the function
+    // in EntryFn
     retq

--- a/src/frame/asm/x86_64_win.asm
+++ b/src/frame/asm/x86_64_win.asm
@@ -1,9 +1,20 @@
 .global tardy_swap_frame
 
 tardy_swap_frame:
+    // Windows stores the upper and lower bounds of the current thread's stack in the
+    // Thread Information Block (TIB), which is accessed via the %gs segment register.
+    // If a Windows exception occurs (or the stack needs to grow), the OS checks if the
+    // current %rsp is within these two limits. If you swap to a new fiber's stack
+    // without updating the TIB, Windows will instantly kill your program with an Access
+    // Violation. By pushing and popping these %gs values, you are ensuring the OS's
+    // internal stack boundary records are swapped alongside the CPU registers.
+
+    // Stack Limit (the lowest memory address / end of the stack)
     pushq %gs:0x10
+    // Stack Base (the highest memory address / start of the stack)
     pushq %gs:0x08
 
+    // Windows additionaly has rdi and rsi as callee saved registers
     pushq %rbx
     pushq %rbp
     pushq %rdi
@@ -13,6 +24,7 @@ tardy_swap_frame:
     pushq %r14
     pushq %r15
 
+    // allocate 160 bytes of space for the 10, 16 bytes (128 bits) %xmmN registers
     subq $160, %rsp
     movups %xmm6, 0x00(%rsp)
     movups %xmm7, 0x10(%rsp)
@@ -25,9 +37,16 @@ tardy_swap_frame:
     movups %xmm14, 0x80(%rsp)
     movups %xmm15, 0x90(%rsp)
 
+    // stack swap
+    // Saves the current CPU Stack Pointer %rsp into the 1st arg (%rcx)
+    // of `tardy_swap_frame` **old_sp
     movq %rsp, (%rcx)
+    // load the %rdx address (from the 2nd arg of `tardy_swap_frame` **new_sp) and
+    // overwrites the CPU's Stack Pointer. The CPU is now executing on the new fiber's
+    // stack.
     movq (%rdx), %rsp
 
+    // Setup new Fibre stack for execution (it follow SysV in spirit)
     movups 0x00(%rsp), %xmm6
     movups 0x10(%rsp), %xmm7
     movups 0x20(%rsp), %xmm8

--- a/src/frame/lib.zig
+++ b/src/frame/lib.zig
@@ -13,31 +13,37 @@ const Hardware = switch (builtin.cpu.arch) {
     else => @compileError("Architecture not currently supported!"),
 };
 
-const FrameEntryFn = *const fn () callconv(.c) noreturn;
+const FrameEntryFn = *allowzero const fn () callconv(.c) noreturn;
 fn EntryFn(args: anytype, comptime func: anytype) FrameEntryFn {
     const Args = @TypeOf(args);
-    return struct {
+    const Fn = struct {
         fn inner() callconv(.c) noreturn {
-            const frame = active_frame.?;
+            const frame_ptr: *Frame = active_frame.?;
 
-            const args_ptr: *Args = @ptrFromInt(@intFromPtr(frame) - @sizeOf(Args));
+            const args_addr = Hardware.alignment.backward(
+                @intFromPtr(frame_ptr) - @sizeOf(Args),
+            );
+            const args_ptr: *Args = @ptrFromInt(args_addr);
+
             @call(.auto, func, args_ptr.*) catch |e| {
                 log.warn("frame failed | {any}", .{e});
-                frame.status = .errored;
+                frame_ptr.status = .errored;
                 Frame.yield();
                 unreachable;
             };
 
             // When our func is done running, just yield.
-            frame.status = .done;
+            frame_ptr.status = .done;
             Frame.yield();
             unreachable;
         }
-    }.inner;
+    };
+    return Fn.inner;
 }
 
 threadlocal var active_frame: ?*Frame = null;
 
+const raw_alignment = Hardware.alignment.toByteUnits();
 pub const Frame = struct {
     const Status = enum(u8) {
         in_progress,
@@ -46,11 +52,11 @@ pub const Frame = struct {
     };
 
     /// The previous SP.
-    caller_sp: *align(Hardware.alignment.toByteUnits()) anyopaque,
+    caller_sp: *align(raw_alignment) anyopaque,
     /// The current SP.
-    current_sp: *align(Hardware.alignment.toByteUnits()) anyopaque,
+    current_sp: *align(raw_alignment) anyopaque,
     /// Stack Info
-    stack_mem: []align(Hardware.alignment.toByteUnits()) u8,
+    stack_mem: []align(raw_alignment) u8,
     /// Is the Frame done?
     status: Status = .in_progress,
 
@@ -59,58 +65,71 @@ pub const Frame = struct {
         stack_size: usize,
         args: anytype,
         comptime func: anytype,
-    ) !*Frame {
+    ) *Frame {
         // TODO: assert minimum stack size
+        // stack_size should be aligned to `Hardware.alignment`
+        debug.assert(Hardware.alignment.check(stack_size));
+
         // Allocate Fiber/Frame Stack with abi alignment
-        const stack = try allocator.alignedAlloc(
+        const stack: []align(raw_alignment) u8 = allocator.alignedAlloc(
             u8,
             Hardware.alignment,
             // in debug mode, SafeAllocator is used by default which requires some extra
             // bookkeeping space for stack trace capturing
+            // TODO: limit multipler to 1.25
             if (builtin.mode == .Debug) stack_size * 2 else stack_size,
-        );
-        errdefer allocator.free(stack);
+        ) catch @panic("OOM");
 
         const stack_base = @intFromPtr(stack.ptr);
         const stack_top = @intFromPtr(stack.ptr + stack.len);
 
         // space for the frame
-        var stack_ptr = Hardware.alignment.backward(
+        const frame_ptr = Hardware.alignment.backward(
             stack_top - @sizeOf(Frame),
         );
-        if (stack_ptr < stack_base) return error.StackTooSmall;
-        const frame: *Frame = @ptrFromInt(stack_ptr);
+        debug.assert(frame_ptr > stack_base);
+
+        const frame: *Frame = @ptrFromInt(frame_ptr);
 
         const Args = @TypeOf(args);
         // space for the args
-        stack_ptr -= @sizeOf(Args);
-        const arg_ptr: *Args = @ptrFromInt(stack_ptr);
+        const args_ptr = Hardware.alignment.backward(
+            frame_ptr - @sizeOf(Args),
+        );
+        debug.assert(args_ptr > stack_base);
+
+        const arg_ptr: *Args = @ptrFromInt(args_ptr);
         arg_ptr.* = args;
 
         // setup space for the `Hardware.stack_count` of callee-saved registers
-        stack_ptr = Hardware.alignment.backward(
-            stack_ptr - @sizeOf(usize) * Hardware.stack_count,
+        const register_ptr = Hardware.alignment.backward(
+            args_ptr - (@sizeOf(usize) * Hardware.stack_count),
         );
-        if (stack_ptr < stack_base) return error.StackTooSmall;
-
-        debug.assert(Hardware.alignment.check(stack_ptr));
+        debug.assert(register_ptr > stack_base);
 
         // address space for the callee-saved registers
-        const register_entries: []FrameEntryFn = @as([*]FrameEntryFn, @ptrFromInt(stack_ptr))[0..Hardware.stack_count];
+        const register_entries: []FrameEntryFn = @as([*]FrameEntryFn, @ptrFromInt(
+            register_ptr,
+        ))[0..Hardware.stack_count];
+
+        // A frame pointer of 0x0 denotes the root of the stack for the DWARF unwinder
+        // so it knows where to stop unwinding.
+        register_entries[Hardware.frame_ptr] = @ptrFromInt(0x0);
+
         // return address/instruction pointer we jump to for the execution of fiber's
         // entry point function after returning from `tardy_swap_frame`
         register_entries[Hardware.entry] = EntryFn(args, func);
 
         frame.* = .{
             .caller_sp = undefined,
-            .current_sp = @ptrFromInt(stack_ptr),
+            .current_sp = @ptrFromInt(register_ptr),
             .stack_mem = stack,
         };
 
         return frame;
     }
 
-    pub fn deinit(self: *const Frame, allocator: std.mem.Allocator) void {
+    pub fn deinit(self: *Frame, allocator: std.mem.Allocator) void {
         allocator.free(self.stack_mem);
     }
 
@@ -132,13 +151,23 @@ pub const Frame = struct {
 };
 
 const x64SysV = struct {
+    /// [0] %r15 pushq %r15 - Lowest Address (where %rsp points)
+    /// [1] %r14 pushq %r14
+    /// [2] %r13 pushq %r13
+    /// [3] %r12 pushq %r12
+    /// [4] %rbp pushq %rbp - Frame Pointer
+    /// [5] %rbx pushq %rbx
+    /// [6] RIP call (implicit) - Entry Function / Return Address
     pub const stack_count = 7;
-    pub const entry = stack_count - 1;
+    /// %rbp
+    pub const frame_ptr = 4;
+    /// Entry Function at Return Address (RIP)
+    pub const entry = 6;
     pub const alignment: std.mem.Alignment = .@"16";
 
     extern fn tardy_swap_frame(
-        noalias **align(alignment.toByteUnits()) anyopaque,
-        noalias **align(alignment.toByteUnits()) anyopaque,
+        noalias **align(raw_alignment) anyopaque,
+        noalias **align(raw_alignment) anyopaque,
     ) callconv(.c) void;
 
     comptime {
@@ -147,13 +176,28 @@ const x64SysV = struct {
 };
 
 const x64Windows = struct {
+    /// [0] to [19] %xmm6 to %xmm15 - Takes up 20 indices (160 bytes total)
+    /// [20] %r15 - First GPR popped (lowest address of pushed GPRs)
+    /// [21] %r14
+    /// [22] %r13
+    /// [23] %r12
+    /// [24] %rsi
+    /// [25] %rdi
+    /// [26] %rbp - Frame Pointer
+    /// [27] %rbx
+    /// [28] %gs:0x08 - Stack Base (Top of Stack)
+    /// [29] %gs:0x10 - Stack Limit (Bottom of Stack)
+    /// [30] RIP - Entry Function / Return Addres
     pub const stack_count = 31;
-    pub const entry = stack_count - 1;
+    /// %rbp
+    pub const frame_ptr = 26;
+    /// Return Address (RIP)
+    pub const entry = 30;
     pub const alignment: std.mem.Alignment = .@"16";
 
     extern fn tardy_swap_frame(
-        noalias **align(alignment.toByteUnits()) anyopaque,
-        noalias **align(alignment.toByteUnits()) anyopaque,
+        noalias **align(raw_alignment) anyopaque,
+        noalias **align(raw_alignment) anyopaque,
     ) callconv(.c) void;
 
     comptime {
@@ -162,17 +206,41 @@ const x64Windows = struct {
 };
 
 const aarch64General = struct {
+    /// [0] fp (x29)  - Lowest Address / Frame Pointer
+    /// [1] lr (x30) - Entry Function / Return Address
+    /// [2] d8
+    /// [3] d9
+    /// [4] d10
+    /// [5] d11
+    /// [6] d12
+    /// [7] d13
+    /// [8] d14
+    /// [9] d15
+    /// [10] x19
+    /// [11] x20
+    /// [12] x21
+    /// [13] x22
+    /// [14] x23
+    /// [15] x24
+    /// [16] x25
+    /// [17] x26
+    /// [18] x27
+    /// [19] x28 - Highest Address
     pub const stack_count = 20;
-    pub const entry = 0;
+    /// Frame Pointer (FP)
+    pub const frame_ptr = 0;
+    /// Entry Function at Link Register (LR)
+    pub const entry = 1;
     pub const alignment: std.mem.Alignment = .@"16";
 
     extern fn tardy_swap_frame(
-        noalias **align(alignment.toByteUnits()) anyopaque,
-        noalias **align(alignment.toByteUnits()) anyopaque,
+        noalias **align(raw_alignment) anyopaque,
+        noalias **align(raw_alignment) anyopaque,
     ) callconv(.c) void;
 
     comptime {
         // TODO: move assembly into `tardy_swap_frame` definition
+        // TODO: allowzero for sp and check if 0x0 so I can skip part of the asm dance
         asm (@embedFile("asm/aarch64_gen.asm"));
     }
 };

--- a/src/frame/lib.zig
+++ b/src/frame/lib.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const assert = std.debug.assert;
+const debug = std.debug;
 const builtin = @import("builtin");
 
 const log = std.log.scoped(.@"tardy/frame");
@@ -20,7 +20,6 @@ fn EntryFn(args: anytype, comptime func: anytype) FrameEntryFn {
         fn inner() callconv(.c) noreturn {
             const frame = active_frame.?;
 
-            //const args_ptr: *align(1) Args = @ptrFromInt(@intFromPtr(frame) - @sizeOf(Args));
             const args_ptr: *Args = @ptrFromInt(@intFromPtr(frame) - @sizeOf(Args));
             @call(.auto, func, args_ptr.*) catch |e| {
                 log.warn("frame failed | {any}", .{e});
@@ -39,7 +38,7 @@ fn EntryFn(args: anytype, comptime func: anytype) FrameEntryFn {
 
 threadlocal var active_frame: ?*Frame = null;
 
-pub const Frame = extern struct {
+pub const Frame = struct {
     const Status = enum(u8) {
         in_progress,
         done,
@@ -47,12 +46,11 @@ pub const Frame = extern struct {
     };
 
     /// The previous SP.
-    caller_sp: [*]u8,
+    caller_sp: *align(Hardware.alignment.toByteUnits()) anyopaque,
     /// The current SP.
-    current_sp: [*]u8,
+    current_sp: *align(Hardware.alignment.toByteUnits()) anyopaque,
     /// Stack Info
-    stack_ptr: [*]u8,
-    stack_len: usize,
+    stack_mem: []align(Hardware.alignment.toByteUnits()) u8,
     /// Is the Frame done?
     status: Status = .in_progress,
 
@@ -62,64 +60,64 @@ pub const Frame = extern struct {
         args: anytype,
         comptime func: anytype,
     ) !*Frame {
-        const stack = try allocator.alloc(u8, stack_size);
+        // TODO: assert minimum stack size
+        // Allocate Fiber/Frame Stack with abi alignment
+        const stack = try allocator.alignedAlloc(
+            u8,
+            Hardware.alignment,
+            // in debug mode, SafeAllocator is used by default which requires some extra
+            // bookkeeping space for stack trace capturing
+            if (builtin.mode == .Debug) stack_size * 2 else stack_size,
+        );
         errdefer allocator.free(stack);
-        const Args = @TypeOf(args);
-
-        if (comptime builtin.mode == .Debug) {
-            // this should mark it easily for the debugger.
-            for (stack) |*byte| byte.* = 0xAA;
-        }
 
         const stack_base = @intFromPtr(stack.ptr);
-        const stack_end = @intFromPtr(stack.ptr + stack.len);
+        const stack_top = @intFromPtr(stack.ptr + stack.len);
 
         // space for the frame
-        var stack_ptr = std.mem.alignBackward(
-            usize,
-            stack_end - @sizeOf(Frame),
-            Hardware.alignment,
+        var stack_ptr = Hardware.alignment.backward(
+            stack_top - @sizeOf(Frame),
         );
         if (stack_ptr < stack_base) return error.StackTooSmall;
         const frame: *Frame = @ptrFromInt(stack_ptr);
 
+        const Args = @TypeOf(args);
         // space for the args
         stack_ptr -= @sizeOf(Args);
         const arg_ptr: *Args = @ptrFromInt(stack_ptr);
         arg_ptr.* = args;
 
-        // space for the saved registers (pushed)
-        stack_ptr = std.mem.alignBackward(
-            usize,
+        // setup space for the `Hardware.stack_count` of callee-saved registers
+        stack_ptr = Hardware.alignment.backward(
             stack_ptr - @sizeOf(usize) * Hardware.stack_count,
-            Hardware.alignment,
         );
         if (stack_ptr < stack_base) return error.StackTooSmall;
-        assert(std.mem.isAligned(stack_ptr, Hardware.alignment));
 
-        // set the return address appropriately
-        const entries: [*]FrameEntryFn = @ptrFromInt(stack_ptr);
-        entries[Hardware.entry] = EntryFn(args, func);
+        debug.assert(Hardware.alignment.check(stack_ptr));
+
+        // address space for the callee-saved registers
+        const register_entries: []FrameEntryFn = @as([*]FrameEntryFn, @ptrFromInt(stack_ptr))[0..Hardware.stack_count];
+        // return address/instruction pointer we jump to for the execution of fiber's
+        // entry point function after returning from `tardy_swap_frame`
+        register_entries[Hardware.entry] = EntryFn(args, func);
 
         frame.* = .{
             .caller_sp = undefined,
             .current_sp = @ptrFromInt(stack_ptr),
-            .stack_ptr = stack.ptr,
-            .stack_len = stack.len,
+            .stack_mem = stack,
         };
 
         return frame;
     }
 
     pub fn deinit(self: *const Frame, allocator: std.mem.Allocator) void {
-        const stack = self.stack_ptr[0..self.stack_len];
-        allocator.free(stack);
+        allocator.free(self.stack_mem);
     }
 
     /// This runs/continues a Frame.
     pub fn proceed(frame: *Frame) void {
         const old_frame = active_frame;
-        assert(old_frame != frame);
+        debug.assert(old_frame != frame);
         active_frame = frame;
         defer active_frame = old_frame;
 
@@ -136,8 +134,12 @@ pub const Frame = extern struct {
 const x64SysV = struct {
     pub const stack_count = 7;
     pub const entry = stack_count - 1;
-    pub const alignment = 16;
-    extern fn tardy_swap_frame(noalias *[*]u8, noalias *[*]u8) callconv(.c) void;
+    pub const alignment: std.mem.Alignment = .@"16";
+
+    extern fn tardy_swap_frame(
+        noalias **align(alignment.toByteUnits()) anyopaque,
+        noalias **align(alignment.toByteUnits()) anyopaque,
+    ) callconv(.c) void;
 
     comptime {
         asm (@embedFile("asm/x86_64_sysv.asm"));
@@ -147,8 +149,12 @@ const x64SysV = struct {
 const x64Windows = struct {
     pub const stack_count = 31;
     pub const entry = stack_count - 1;
-    pub const alignment = 16;
-    extern fn tardy_swap_frame(noalias *[*]u8, noalias *[*]u8) callconv(.c) void;
+    pub const alignment: std.mem.Alignment = .@"16";
+
+    extern fn tardy_swap_frame(
+        noalias **align(alignment.toByteUnits()) anyopaque,
+        noalias **align(alignment.toByteUnits()) anyopaque,
+    ) callconv(.c) void;
 
     comptime {
         asm (@embedFile("asm/x86_64_win.asm"));
@@ -158,10 +164,15 @@ const x64Windows = struct {
 const aarch64General = struct {
     pub const stack_count = 20;
     pub const entry = 0;
-    pub const alignment = 16;
-    extern fn tardy_swap_frame(noalias *[*]u8, noalias *[*]u8) callconv(.c) void;
+    pub const alignment: std.mem.Alignment = .@"16";
+
+    extern fn tardy_swap_frame(
+        noalias **align(alignment.toByteUnits()) anyopaque,
+        noalias **align(alignment.toByteUnits()) anyopaque,
+    ) callconv(.c) void;
 
     comptime {
+        // TODO: move assembly into `tardy_swap_frame` definition
         asm (@embedFile("asm/aarch64_gen.asm"));
     }
 };

--- a/src/runtime/scheduler.zig
+++ b/src/runtime/scheduler.zig
@@ -6,7 +6,8 @@ const AtomicDynamicBitSet = @import("../core/atomic_bitset.zig").AtomicDynamicBi
 const Pool = @import("../core/pool.zig").Pool;
 const PoolKind = @import("../core/pool.zig").PoolKind;
 const Queue = @import("../core/queue.zig").Queue;
-const Frame = @import("../frame/lib.zig").Frame;
+const frame = @import("../frame/lib.zig");
+const Frame = frame.Frame;
 const Runtime = @import("lib.zig").Runtime;
 const Task = @import("task.zig").Task;
 
@@ -42,6 +43,10 @@ pub const Scheduler = struct {
     }
 
     pub fn deinit(sched: *Scheduler, io: std.Io) void {
+        var iter = sched.tasks.iterator();
+        while (iter.next_ptr()) |task| {
+            task.frame.deinit(sched.allocator);
+        }
         sched.tasks.deinit();
         sched.released.deinit(sched.allocator);
         sched.triggers.deinit(sched.allocator, io);
@@ -97,11 +102,11 @@ pub const Scheduler = struct {
             }
         };
 
-        const frame: *Frame = try .init(self.allocator, stack_size, frame_ctx, frame_fn);
+        const frame_ptr: *Frame = .init(self.allocator, stack_size, frame_ctx, frame_fn);
 
         const item: Task = .{
             .index = index,
-            .frame = frame,
+            .frame = frame_ptr,
             .state = .dead,
         };
         const item_ptr = self.tasks.get_ptr(index);

--- a/test/e2e/file_chain.zig
+++ b/test/e2e/file_chain.zig
@@ -94,7 +94,7 @@ pub const FileChain = struct {
         };
     }
 
-    pub fn deinit(self: *const FileChain, allocator: std.mem.Allocator) void {
+    pub fn deinit(self: *FileChain, allocator: std.mem.Allocator) void {
         defer allocator.free(self.steps);
         defer allocator.free(self.buffer);
         defer switch (self.path) {

--- a/test/e2e/main.zig
+++ b/test/e2e/main.zig
@@ -33,8 +33,6 @@ const max_stderr_output = 9 * 1024 * 1024;
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
     const gpa = init.gpa;
-    var arena_alloc = init.arena;
-    const arena = arena_alloc.allocator();
     var args = try init.minimal.args.iterateAllocator(gpa);
     defer args.deinit();
 
@@ -56,7 +54,7 @@ pub fn main(init: std.process.Init) !void {
         if (length >= maybe_seed_buffer.len) @panic("seed too long to be a u64");
 
         assert(length < maybe_seed_buffer.len);
-        mem.copyForwards(u8, &maybe_seed_buffer, pre_new);
+        @memcpy(maybe_seed_buffer[0..length], pre_new);
         maybe_seed_buffer[length] = 0;
         break :blk maybe_seed_buffer[0..length :0];
     };
@@ -76,9 +74,7 @@ pub fn main(init: std.process.Init) !void {
     };
     log.debug("{f}", .{std.json.fmt(shared, .{ .whitespace = .indent_1 })});
 
-    // TODO: find out why using gpa here gives
-    // thread panic: incorrect alignment on aarch64-linux/macos
-    var tardy: Tardy = try .init(arena, io, .{
+    var tardy: Tardy = try .init(gpa, io, .{
         .threading = .{ .multi = 2 },
         .pooling = .grow,
         .size_tasks_initial = shared.size_tasks_initial,


### PR DESCRIPTION
- Added explicit alignments in `Frame` pointer fields
- Replace many item pointers with an aligned `anyopaque` pointer
- Align Frame stack allocation to ABI requirements
- Increase `Frame` stack size by a multiple of 2 in debug mode to give ample space for `SafeAllocator` stack trace capturing
- Cleanup `Frame.init`
- Use `mem.Alignment` type for `Hardware.alignment` instead of raw integers
- Update `tardy_swap_frame` function signature

fixes all tested traces of `thread panic: incorrect alignment` on
aarch64 when using init.gpa

e2e.main
- use gpa since the alginement panic issue for aarch64 has been fixed now
- replace mem.copyForwards with `@memcpy`

Frame type (TODO: rename to Fibre)
- make .init non failable
- assert alignments of stack_size and make stack space aligned to ABI
- align all pointers in the Fibre
- assert size requirements instead of returning StackTooSmall
- set Fibre frame pointer to null (0x0) to denote end of stack to the unwinder
- make Frame arg of deinit non-const
- document layout of registers for each architecture on their `stack_count` variable
- document other variables in `Hardware.*`

EntryFn
- make FrameEntryFn an *allowzero ptr
- align args_addr in `EntryFn.Fn.inner` else we load invalid memory address which leads to segfults

aarch64 tardy_swap_frame
- use the standard fp, lr pair structure
- add descriptive comments in asm to explain instruction and actions
- fix debug unwinding by limit the unwind scope to the Fiber stack frame

64SysV tardy_swap_frame
- add descriptive comments to make implicit action obvious

64Win tardy_swap_frame
- document windows TIB stack limits usage
- document where the win abi deviates from SysV

runtime.Scheduler
- improve deinit to leak less memory
- use new Frame.init signature

ChainFile
- make deinit arg non-const

tested with below using `init.gpa`
```elvish
❯ zig build  -Dtarget=aarch64-linux -fqemu -Dasync=poll test_e2e -- 1828828288888888888
```

closes #42