### PR TITLE
Use Explicit allocators

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -182,8 +182,11 @@ fn build_example_exe(
 
     // windows: errors with `unknow size: 0xx(%%rsp)` without llvm
     // aarch64: use_new_linker panics and codegen deadlocks without llvm
-    const use_llvm = (options.target.result.os.tag == .windows) or
-        (options.target.result.cpu.arch == .aarch64);
+    // macos: doesn't currently support new_linker
+    const use_llvm = switch (options.target.result.os.tag) {
+        .windows, .macos => true,
+        else => if (options.target.result.cpu.arch == .aarch64) true else false,
+    };
     const example_exe = b.addExecutable(.{
         .name = @tagName(options.example),
         .root_module = example_mod,
@@ -314,10 +317,10 @@ fn build_test_e2e(
 
     e2e_mod.addOptions("options", test_options);
 
-    // windows: errors with `unknow size: 0xx(%%rsp)` without llvm
-    // aarch64: use_new_linker panics and codegen deadlocks without llvm
-    const use_llvm = (options.target.result.os.tag == .windows) or
-        (options.target.result.cpu.arch == .aarch64);
+    const use_llvm = switch (options.target.result.os.tag) {
+        .windows, .macos => true,
+        else => if (options.target.result.cpu.arch == .aarch64) true else false,
+    };
     const exe = b.addExecutable(.{
         .name = "e2e",
         .root_module = e2e_mod,

--- a/examples/channel/main.zig
+++ b/examples/channel/main.zig
@@ -44,7 +44,7 @@ fn consumer_frame(rt: *Runtime, consumer: Spsc(usize).Consumer) !void {
 
 pub fn main(init: std.process.Init) !void {
     var channel: Spsc(usize) = try .init(init.gpa, 2);
-    defer channel.deinit();
+    defer channel.deinit(init.gpa);
 
     var td: Tardy = try .init(init.gpa, init.io, .{
         .threading = .{ .multi = 2 },

--- a/src/AsyncIO.zig
+++ b/src/AsyncIO.zig
@@ -15,45 +15,55 @@ mutex: Io.Mutex = .init,
 /// This provides the completions that the backend will utilize when
 /// submitting and reaping. This MUST be called before any other
 /// methods on this AsyncIO instance.
-pub fn attach(self: *AsyncIO, completions: []results.Completion) void {
-    self.completions = completions;
-    self.attached = true;
+pub fn attach(async_io: *AsyncIO, completions: []results.Completion) void {
+    async_io.completions = completions;
+    async_io.attached = true;
 }
 
-pub fn deinit(self: *AsyncIO, allocator: mem.Allocator, io: Io) void {
-    self.mutex.lockUncancelable(io);
-    defer self.mutex.unlock(io);
+pub fn deinit(async_io: *AsyncIO, allocator: mem.Allocator, io: Io) void {
+    async_io.mutex.lockUncancelable(io);
+    defer async_io.mutex.unlock(io);
 
-    self.vtable.deinit(self.runner, allocator);
+    async_io.vtable.deinit(async_io.runner, allocator);
 }
 
 pub fn queue_job(
-    self: *AsyncIO,
+    async_io: *AsyncIO,
     allocator: mem.Allocator,
     task: usize,
     sub: Submission,
 ) QueueJobError!void {
-    debug.assert(self.attached);
+    debug.assert(async_io.attached);
     log.debug("queuing up job={t} at index={d}", .{ sub, task });
-    try self.vtable.queue_job(self.runner, allocator, task, sub);
+    try async_io.vtable.queue_job(async_io.runner, allocator, task, sub);
 }
 
-pub fn wake(self: *AsyncIO, io: Io) !void {
-    self.mutex.lockUncancelable(io);
-    defer self.mutex.unlock(io);
+pub fn wake(async_io: *AsyncIO, io: Io) !void {
+    async_io.mutex.lockUncancelable(io);
+    defer async_io.mutex.unlock(io);
 
-    debug.assert(self.attached);
-    try self.vtable.wake(self.runner);
+    debug.assert(async_io.attached);
+    try async_io.vtable.wake(async_io.runner);
 }
 
-pub fn reap(self: *AsyncIO, allocator: mem.Allocator, wait: bool) ![]results.Completion {
-    debug.assert(self.attached);
-    return try self.vtable.reap(self.runner, allocator, self.completions, wait);
+pub fn reap(
+    async_io: *AsyncIO,
+    allocator: mem.Allocator,
+    wait: bool,
+) ![]results.Completion {
+    debug.assert(async_io.attached);
+
+    return try async_io.vtable.reap(
+        async_io.runner,
+        allocator,
+        async_io.completions,
+        wait,
+    );
 }
 
-pub fn submit(self: *AsyncIO) !void {
-    debug.assert(self.attached);
-    try self.vtable.submit(self.runner);
+pub fn submit(async_io: *AsyncIO) !void {
+    debug.assert(async_io.attached);
+    try async_io.vtable.submit(async_io.runner);
 }
 
 pub const Kind = union(enum) {
@@ -129,7 +139,9 @@ pub fn native() Kind {
         .ios, .macos, .watchos, .tvos, .visionos => return Kind.kqueue,
         .freebsd, .openbsd, .netbsd, .dragonfly => return Kind.kqueue,
         .illumos => return Kind.poll,
-        else => @compileError("Unsupported platform! Provide a custom Async I/O backend."),
+        else => @compileError(
+            "Unsupported platform! Provide a custom Async I/O backend.",
+        ),
     };
 }
 
@@ -178,8 +190,8 @@ pub const Features = struct {
         return .{ .bitmask = mask };
     }
 
-    pub fn has_capability(self: Features, op: Op) bool {
-        return (self.bitmask & @backingInt(op)) != 0;
+    pub fn has_capability(features: Features, op: Op) bool {
+        return (features.bitmask & @backingInt(op)) != 0;
     }
 };
 

--- a/src/AsyncIO.zig
+++ b/src/AsyncIO.zig
@@ -111,12 +111,12 @@ pub const Kind = union(enum) {
             .epoll => Epoll,
             .poll => Poll,
             .kqueue => Kqueue,
-            .custom => |inner| {
-                debug.assert(std.meta.hasMethod(inner, "init"));
-                debug.assert(std.meta.hasMethod(inner, "inner_deinit"));
-                debug.assert(std.meta.hasMethod(inner, "queue_job"));
-                debug.assert(std.meta.hasMethod(inner, "to_async"));
-                return inner;
+            .custom => |custom| {
+                debug.assert(std.meta.hasMethod(custom, "init"));
+                debug.assert(std.meta.hasMethod(custom, "inner_deinit"));
+                debug.assert(std.meta.hasMethod(custom, "queue_job"));
+                debug.assert(std.meta.hasMethod(custom, "to_async"));
+                return custom;
             },
             .auto => continue :sw native(),
         };

--- a/src/AsyncIO.zig
+++ b/src/AsyncIO.zig
@@ -27,10 +27,15 @@ pub fn deinit(self: *AsyncIO, allocator: mem.Allocator, io: Io) void {
     self.vtable.deinit(self.runner, allocator);
 }
 
-pub fn queue_job(self: *AsyncIO, task: usize, sub: Submission) QueueJobError!void {
+pub fn queue_job(
+    self: *AsyncIO,
+    allocator: mem.Allocator,
+    task: usize,
+    sub: Submission,
+) QueueJobError!void {
     debug.assert(self.attached);
     log.debug("queuing up job={t} at index={d}", .{ sub, task });
-    try self.vtable.queue_job(self.runner, task, sub);
+    try self.vtable.queue_job(self.runner, allocator, task, sub);
 }
 
 pub fn wake(self: *AsyncIO, io: Io) !void {
@@ -41,9 +46,9 @@ pub fn wake(self: *AsyncIO, io: Io) !void {
     try self.vtable.wake(self.runner);
 }
 
-pub fn reap(self: *AsyncIO, wait: bool) ![]results.Completion {
+pub fn reap(self: *AsyncIO, allocator: mem.Allocator, wait: bool) ![]results.Completion {
     debug.assert(self.attached);
-    return try self.vtable.reap(self.runner, self.completions, wait);
+    return try self.vtable.reap(self.runner, allocator, self.completions, wait);
 }
 
 pub fn submit(self: *AsyncIO) !void {
@@ -258,10 +263,20 @@ pub const QueueJobError = IoUring.Errors.QueueJob ||
     Kqueue.Errors.QueueJob;
 
 const VTable = struct {
-    queue_job: *const fn (*anyopaque, usize, Submission) QueueJobError!void,
+    queue_job: *const fn (
+        *anyopaque,
+        mem.Allocator,
+        usize,
+        Submission,
+    ) QueueJobError!void,
     deinit: *const fn (*anyopaque, mem.Allocator) void,
     wake: *const fn (*anyopaque) anyerror!void,
-    reap: *const fn (*anyopaque, []results.Completion, bool) anyerror![]results.Completion,
+    reap: *const fn (
+        *anyopaque,
+        mem.Allocator,
+        []results.Completion,
+        bool,
+    ) anyerror![]results.Completion,
     submit: *const fn (*anyopaque) anyerror!void,
 };
 

--- a/src/Coroutine.zig
+++ b/src/Coroutine.zig
@@ -2,13 +2,6 @@
 pub const Coroutine = @This();
 
 threadlocal var active_frame: ?*Coroutine = null;
-
-const Status = enum(u8) {
-    in_progress,
-    done,
-    errored,
-};
-
 /// The previous SP.
 caller_sp: *align(raw_alignment) anyopaque,
 /// The current SP.
@@ -17,6 +10,12 @@ current_sp: *align(raw_alignment) anyopaque,
 stack_mem: []align(raw_alignment) u8,
 /// Is the Coroutine Frame done?
 status: Status = .in_progress,
+
+const Status = enum(u8) {
+    in_progress,
+    done,
+    errored,
+};
 
 pub const Stack = enum(u32) {
     @"2KiB" = 2 * unit,
@@ -148,8 +147,8 @@ pub fn init(
     return frame;
 }
 
-pub fn deinit(self: *Coroutine, allocator: mem.Allocator) void {
-    allocator.free(self.stack_mem);
+pub fn deinit(frame: *Coroutine, allocator: mem.Allocator) void {
+    allocator.free(frame.stack_mem);
 }
 
 /// This runs/continues a Coroutine Frame.

--- a/src/Coroutine.zig
+++ b/src/Coroutine.zig
@@ -18,7 +18,7 @@ stack_mem: []align(raw_alignment) u8,
 /// Is the Coroutine Frame done?
 status: Status = .in_progress,
 
-pub const Stack = enum(usize) {
+pub const Stack = enum(u32) {
     @"2KiB" = 2 * unit,
     @"4KiB" = 4 * unit,
     @"8KiB" = 8 * unit,

--- a/src/Coroutine.zig
+++ b/src/Coroutine.zig
@@ -177,7 +177,7 @@ const RegisterFn = *allowzero const fn () callconv(.c) noreturn;
 fn EntryFn(comptime coroutine_fn: anytype, args: anytype) RegisterFn {
     const Args = @TypeOf(args);
     const Fn = struct {
-        fn inner() callconv(.c) noreturn {
+        fn entry() callconv(.c) noreturn {
             const frame_ptr: *Coroutine = active_frame.?;
 
             const args_addr = Frame.alignment.backward(
@@ -193,9 +193,14 @@ fn EntryFn(comptime coroutine_fn: anytype, args: anytype) RegisterFn {
             };
 
             if (builtin.mode == .debug) {
-                log.debug("Coroutine \nfn: `* const {any}`\nUsed {Bi} / {Bi} bytes of stack", .{
-                    @TypeOf(coroutine_fn), frame_ptr.stackUsed(), frame_ptr.stack_mem.len,
-                });
+                log.debug(
+                    "Coroutine \nfn: `* const {any}`\nUsed {Bi} / {Bi} bytes of stack",
+                    .{
+                        @TypeOf(coroutine_fn),
+                        frame_ptr.stackUsed(),
+                        frame_ptr.stack_mem.len,
+                    },
+                );
             }
 
             // When our coroutine is done running, just yield.
@@ -204,7 +209,7 @@ fn EntryFn(comptime coroutine_fn: anytype, args: anytype) RegisterFn {
             unreachable;
         }
     };
-    return Fn.inner;
+    return Fn.entry;
 }
 
 const is_unix = builtin.os.tag != .windows;

--- a/src/Runtime.zig
+++ b/src/Runtime.zig
@@ -41,7 +41,7 @@ pub fn init(
 
 pub fn deinit(rt: *Runtime) void {
     rt.storage.deinit();
-    rt.scheduler.deinit(rt.io);
+    rt.scheduler.deinit(rt.allocator, rt.io);
     rt.allocator.free(rt.aio.completions);
     rt.aio.deinit(rt.allocator, rt.io);
 }
@@ -79,6 +79,7 @@ pub fn spawn(
     stack_size: ?Coroutine.Stack,
 ) !void {
     try rt.scheduler.spawn(
+        rt.allocator,
         coroutine_fn,
         args,
         stack_size,
@@ -98,7 +99,7 @@ fn run_task(rt: *Runtime, task: *Task) !void {
             // so we only hit that condition sometimes in here.
             const index = rt.current_task.?;
             // If the frame is done, clean it up.
-            try rt.scheduler.release(index);
+            try rt.scheduler.release(rt.allocator, index);
             // frees the heap-allocated stack.
             //
             // this should be evaluted as it does have a perf impact but
@@ -112,7 +113,7 @@ fn run_task(rt: *Runtime, task: *Task) !void {
         .errored => {
             const index = rt.current_task.?;
             log.warn("cleaning up failed frame...", .{});
-            try rt.scheduler.release(index);
+            try rt.scheduler.release(rt.allocator, index);
             frame.deinit(rt.allocator);
         },
     }
@@ -171,7 +172,10 @@ pub fn run(rt: *Runtime) !void {
         const wait_for_io = rt.scheduler.runnable == 0;
         log.debug("{d} - Wait for I/O: {}", .{ rt.id, wait_for_io });
 
-        const completions = try rt.aio.reap(wait_for_io);
+        const completions = try rt.aio.reap(
+            rt.allocator,
+            wait_for_io,
+        );
         for (completions) |completion| {
             if (completion.result == .wake) {
                 force_woken = true;

--- a/src/aio/Epoll.zig
+++ b/src/aio/Epoll.zig
@@ -18,8 +18,12 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) !Epoll {
     const events = try allocator.alloc(linux.epoll_event, options.size_aio_reap_max);
     errdefer allocator.free(events);
 
-    var jobs: pool.Pool(Job) = try .init(allocator, size, options.pooling);
-    errdefer jobs.deinit();
+    var jobs: pool.Pool(Job) = try .init(
+        allocator,
+        size,
+        options.pooling,
+    );
+    errdefer jobs.deinit(allocator);
 
     // Queue the wake task.
     const index = jobs.borrow_assume_unset(0);
@@ -45,11 +49,11 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) !Epoll {
     };
 }
 
-pub fn inner_deinit(self: *Epoll, allocator: mem.Allocator) void {
-    syscall.close(self.epoll_fd);
-    allocator.free(self.events);
-    self.jobs.deinit();
-    syscall.close(self.wake_event_fd);
+pub fn inner_deinit(epoll: *Epoll, allocator: mem.Allocator) void {
+    syscall.close(epoll.epoll_fd);
+    allocator.free(epoll.events);
+    epoll.jobs.deinit(allocator);
+    syscall.close(epoll.wake_event_fd);
 }
 
 fn deinit(runner: *anyopaque, allocator: mem.Allocator) void {
@@ -59,31 +63,68 @@ fn deinit(runner: *anyopaque, allocator: mem.Allocator) void {
 
 pub fn queue_job(
     runner: *anyopaque,
+    allocator: mem.Allocator,
     task: usize,
     job: AsyncIO.Submission,
 ) Errors.QueueJob!void {
     const epoll: *Epoll = @ptrCast(@alignCast(runner));
 
     try switch (job) {
-        .timer => |inner| queue_timer(epoll, task, inner),
-        .accept => |inner| queue_accept(epoll, task, inner.socket, inner.kind),
-        .connect => |inner| queue_connect(epoll, task, inner.socket, inner.addr, inner.kind),
-        .recv => |inner| queue_recv(epoll, task, inner.socket, inner.buffer),
-        .send => |inner| queue_send(epoll, task, inner.socket, inner.buffer),
+        .timer => |inner| queue_timer(
+            epoll,
+            allocator,
+            task,
+            inner,
+        ),
+        .accept => |inner| queue_accept(
+            epoll,
+            allocator,
+            task,
+            inner.socket,
+            inner.kind,
+        ),
+        .connect => |inner| queue_connect(
+            epoll,
+            allocator,
+            task,
+            inner.socket,
+            inner.addr,
+            inner.kind,
+        ),
+        .recv => |inner| queue_recv(
+            epoll,
+            allocator,
+            task,
+            inner.socket,
+            inner.buffer,
+        ),
+        .send => |inner| queue_send(
+            epoll,
+            allocator,
+            task,
+            inner.socket,
+            inner.buffer,
+        ),
         .open, .delete, .mkdir, .stat, .read, .write, .close => unreachable,
     };
 }
 
-fn queue_timer(self: *Epoll, task: usize, duration: Io.Duration) Errors.Timer!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
+fn queue_timer(
+    epoll: *Epoll,
+    allocator: mem.Allocator,
+    task: usize,
+    duration: Io.Duration,
+) Errors.Timer!void {
+    const index = try epoll.jobs.borrow_hint(allocator, task);
+    errdefer epoll.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = epoll.jobs.get_ptr(index);
 
     const timer_fd = try syscall.timerfd_create(
         linux.TIMERFD_CLOCK.MONOTONIC,
         .{ .NONBLOCK = true },
     );
+
     const ktimerspec: linux.itimerspec = .{
         .it_value = .{
             .sec = @intCast(@divFloor(duration.nanoseconds, std.time.ns_per_s)),
@@ -92,7 +133,12 @@ fn queue_timer(self: *Epoll, task: usize, duration: Io.Duration) Errors.Timer!vo
         .it_interval = .{ .sec = 0, .nsec = 0 },
     };
 
-    try syscall.timerfd_settime(timer_fd, .{}, &ktimerspec, null);
+    try syscall.timerfd_settime(
+        timer_fd,
+        .{},
+        &ktimerspec,
+        null,
+    );
     item.* = .{
         .index = index,
         .type = .{ .timer = .{ .fd = timer_fd } },
@@ -104,19 +150,20 @@ fn queue_timer(self: *Epoll, task: usize, duration: Io.Duration) Errors.Timer!vo
         .data = .{ .u64 = index },
     };
 
-    try self.add_fd(timer_fd, &event);
+    try epoll.add_fd(timer_fd, &event);
 }
 
 fn queue_accept(
-    self: *Epoll,
+    epoll: *Epoll,
+    allocator: mem.Allocator,
     task: usize,
     socket: net.Socket.Handle,
     kind: net.Socket.Kind,
 ) Errors.Accept!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
+    const index = try epoll.jobs.borrow_hint(allocator, task);
+    errdefer epoll.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = epoll.jobs.get_ptr(index);
     item.* = .{
         .index = index,
         .type = .{
@@ -134,21 +181,22 @@ fn queue_accept(
         .data = .{ .u64 = index },
     };
 
-    try self.add_or_mod_fd(socket, &event);
+    try epoll.add_or_mod_fd(socket, &event);
 }
 
 fn queue_connect(
-    self: *Epoll,
+    epoll: *Epoll,
+    allocator: mem.Allocator,
     task: usize,
     socket: net.Socket.Handle,
     // TODO: take *const
     addr: net.Socket.Address,
     kind: net.Socket.Kind,
 ) Errors.Connect!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
+    const index = try epoll.jobs.borrow_hint(allocator, task);
+    errdefer epoll.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = epoll.jobs.get_ptr(index);
     item.* = .{
         .index = index,
         .type = .{
@@ -174,19 +222,20 @@ fn queue_connect(
         .data = .{ .u64 = index },
     };
 
-    try self.add_or_mod_fd(socket, &event);
+    try epoll.add_or_mod_fd(socket, &event);
 }
 
 fn queue_recv(
-    self: *Epoll,
+    epoll: *Epoll,
+    allocator: mem.Allocator,
     task: usize,
     socket: net.Socket.Handle,
     buffer: []u8,
 ) Errors.Recv!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
+    const index = try epoll.jobs.borrow_hint(allocator, task);
+    errdefer epoll.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = epoll.jobs.get_ptr(index);
     item.* = .{
         .index = index,
         .type = .{
@@ -203,19 +252,20 @@ fn queue_recv(
         .data = .{ .u64 = index },
     };
 
-    try self.add_or_mod_fd(socket, &event);
+    try epoll.add_or_mod_fd(socket, &event);
 }
 
 fn queue_send(
-    self: *Epoll,
+    epoll: *Epoll,
+    allocator: mem.Allocator,
     task: usize,
     socket: net.Socket.Handle,
     buffer: []const u8,
 ) Errors.Send!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
+    const index = try epoll.jobs.borrow_hint(allocator, task);
+    errdefer epoll.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = epoll.jobs.get_ptr(index);
     item.* = .{
         .index = index,
         .type = .{
@@ -232,32 +282,55 @@ fn queue_send(
         .data = .{ .u64 = index },
     };
 
-    try self.add_or_mod_fd(socket, &event);
+    try epoll.add_or_mod_fd(socket, &event);
 }
 
 fn add_or_mod_fd(
-    self: *Epoll,
+    epoll: *Epoll,
     fd: posix.fd_t,
     event: *linux.epoll_event,
 ) syscall.EpollCtlError!void {
-    self.add_fd(fd, event) catch |e| switch (e) {
+    epoll.add_fd(fd, event) catch |e| switch (e) {
         error.FileDescriptorAlreadyPresentInSet => {
-            try self.mod_fd(fd, event);
+            try epoll.mod_fd(fd, event);
         },
         else => |err| return err,
     };
 }
 
-fn add_fd(self: *Epoll, fd: posix.fd_t, event: *linux.epoll_event) syscall.EpollCtlError!void {
-    try syscall.epoll_ctl(self.epoll_fd, linux.EPOLL.CTL_ADD, fd, event);
+fn add_fd(
+    epoll: *Epoll,
+    fd: posix.fd_t,
+    event: *linux.epoll_event,
+) syscall.EpollCtlError!void {
+    try syscall.epoll_ctl(
+        epoll.epoll_fd,
+        linux.EPOLL.CTL_ADD,
+        fd,
+        event,
+    );
 }
 
-fn mod_fd(self: *Epoll, fd: posix.fd_t, event: *linux.epoll_event) syscall.EpollCtlError!void {
-    try syscall.epoll_ctl(self.epoll_fd, linux.EPOLL.CTL_MOD, fd, event);
+fn mod_fd(
+    epoll: *Epoll,
+    fd: posix.fd_t,
+    event: *linux.epoll_event,
+) syscall.EpollCtlError!void {
+    try syscall.epoll_ctl(
+        epoll.epoll_fd,
+        linux.EPOLL.CTL_MOD,
+        fd,
+        event,
+    );
 }
 
-fn remove_fd(self: *Epoll, fd: posix.fd_t) syscall.EpollCtlError!void {
-    try syscall.epoll_ctl(self.epoll_fd, linux.EPOLL.CTL_DEL, fd, null);
+fn remove_fd(epoll: *Epoll, fd: posix.fd_t) syscall.EpollCtlError!void {
+    try syscall.epoll_ctl(
+        epoll.epoll_fd,
+        linux.EPOLL.CTL_DEL,
+        fd,
+        null,
+    );
 }
 
 pub fn wake(runner: *anyopaque) syscall.WriteError!void {
@@ -274,6 +347,7 @@ pub fn submit(_: *anyopaque) !void {}
 
 pub fn reap(
     runner: *anyopaque,
+    _: mem.Allocator,
     completions: []results.Completion,
     wait: bool,
 ) ![]results.Completion {
@@ -285,14 +359,21 @@ pub fn reap(
         if (remaining == 0) break;
 
         const timeout: i32 = if (!wait) 0 else -1;
+
         // Handle all of the epoll I/O
-        const epoll_events = syscall.epoll_wait(epoll.epoll_fd, epoll.events[0..remaining], timeout);
+        const epoll_events = syscall.epoll_wait(
+            epoll.epoll_fd,
+            epoll.events[0..remaining],
+            timeout,
+        );
+
         for (epoll.events[0..epoll_events]) |event| {
             const job_index: usize = @intCast(event.data.u64);
             debug.assert(epoll.jobs.dirty.isSet(job_index));
 
             var job_complete = true;
             defer if (job_complete) epoll.jobs.release(job_index);
+
             const job = epoll.jobs.get_ptr(job_index);
 
             const result: results.Result = blk: {
@@ -442,9 +523,9 @@ pub fn reap(
     return completions[0..reaped];
 }
 
-pub fn to_async(self: *Epoll) AsyncIO {
+pub fn to_async(epoll: *Epoll) AsyncIO {
     return .{
-        .runner = self,
+        .runner = epoll,
         .features = .init(&.{
             .timer,
             .accept,

--- a/src/aio/Epoll.zig
+++ b/src/aio/Epoll.zig
@@ -12,10 +12,16 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) !Epoll {
     debug.assert(epoll_fd > -1);
     errdefer syscall.close(epoll_fd);
 
-    const wake_event_fd: posix.fd_t = try syscall.eventfd(0, linux.EFD.CLOEXEC);
+    const wake_event_fd: posix.fd_t = try syscall.eventfd(
+        0,
+        linux.EFD.CLOEXEC,
+    );
     errdefer syscall.close(wake_event_fd);
 
-    const events = try allocator.alloc(linux.epoll_event, options.size_aio_reap_max);
+    const events = try allocator.alloc(
+        linux.epoll_event,
+        options.size_aio_reap_max,
+    );
     errdefer allocator.free(events);
 
     var jobs: pool.Pool(Job) = try .init(
@@ -39,7 +45,12 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) !Epoll {
         .data = .{ .u64 = index },
     };
 
-    try syscall.epoll_ctl(epoll_fd, linux.EPOLL.CTL_ADD, wake_event_fd, &event);
+    try syscall.epoll_ctl(
+        epoll_fd,
+        linux.EPOLL.CTL_ADD,
+        wake_event_fd,
+        &event,
+    );
 
     return .{
         .epoll_fd = epoll_fd,
@@ -70,36 +81,31 @@ pub fn queue_job(
     const epoll: *Epoll = @ptrCast(@alignCast(runner));
 
     try switch (job) {
-        .timer => |inner| queue_timer(
-            epoll,
+        .timer => |inner| epoll.queue_timer(
             allocator,
             task,
             inner,
         ),
-        .accept => |inner| queue_accept(
-            epoll,
+        .accept => |inner| epoll.queue_accept(
             allocator,
             task,
             inner.socket,
             inner.kind,
         ),
-        .connect => |inner| queue_connect(
-            epoll,
+        .connect => |inner| epoll.queue_connect(
             allocator,
             task,
             inner.socket,
             inner.addr,
             inner.kind,
         ),
-        .recv => |inner| queue_recv(
-            epoll,
+        .recv => |inner| epoll.queue_recv(
             allocator,
             task,
             inner.socket,
             inner.buffer,
         ),
-        .send => |inner| queue_send(
-            epoll,
+        .send => |inner| epoll.queue_send(
             allocator,
             task,
             inner.socket,
@@ -385,7 +391,10 @@ pub fn reap(
                         var buffer: [8]u8 = undefined;
 
                         // Should NEVER fail.
-                        _ = syscall.read(epoll.wake_event_fd, buffer[0..]) catch |e| {
+                        _ = syscall.read(
+                            epoll.wake_event_fd,
+                            buffer[0..],
+                        ) catch |e| {
                             log.err("wake failed: {}", .{e});
                             unreachable;
                         };
@@ -399,7 +408,10 @@ pub fn reap(
 
                         var buffer: [8]u8 = undefined;
                         // Should NEVER fail.
-                        _ = syscall.read(timer_fd, buffer[0..]) catch |e| {
+                        _ = syscall.read(
+                            timer_fd,
+                            buffer[0..],
+                        ) catch |e| {
                             log.debug("timer failed: {}", .{e});
                             unreachable;
                         };

--- a/src/aio/Epoll.zig
+++ b/src/aio/Epoll.zig
@@ -81,35 +81,35 @@ pub fn queue_job(
     const epoll: *Epoll = @ptrCast(@alignCast(runner));
 
     try switch (job) {
-        .timer => |inner| epoll.queue_timer(
+        .timer => |timer| epoll.queue_timer(
             allocator,
             task,
-            inner,
+            timer,
         ),
-        .accept => |inner| epoll.queue_accept(
+        .accept => |accept| epoll.queue_accept(
             allocator,
             task,
-            inner.socket,
-            inner.kind,
+            accept.socket,
+            accept.kind,
         ),
-        .connect => |inner| epoll.queue_connect(
+        .connect => |connect| epoll.queue_connect(
             allocator,
             task,
-            inner.socket,
-            inner.addr,
-            inner.kind,
+            connect.socket,
+            connect.addr,
+            connect.kind,
         ),
-        .recv => |inner| epoll.queue_recv(
+        .recv => |recv| epoll.queue_recv(
             allocator,
             task,
-            inner.socket,
-            inner.buffer,
+            recv.socket,
+            recv.buffer,
         ),
-        .send => |inner| epoll.queue_send(
+        .send => |send| epoll.queue_send(
             allocator,
             task,
-            inner.socket,
-            inner.buffer,
+            send.socket,
+            send.buffer,
         ),
         .open, .delete, .mkdir, .stat, .read, .write, .close => unreachable,
     };
@@ -401,8 +401,8 @@ pub fn reap(
 
                         break :blk .wake;
                     },
-                    .timer => |inner| {
-                        const timer_fd = inner.fd;
+                    .timer => |timer| {
+                        const timer_fd = timer.fd;
                         defer epoll.remove_fd(timer_fd) catch unreachable;
                         debug.assert(event.events & linux.EPOLL.IN != 0);
 
@@ -418,13 +418,13 @@ pub fn reap(
 
                         break :blk .none;
                     },
-                    .accept => |*inner| {
+                    .accept => |*accept| {
                         debug.assert(event.events & linux.EPOLL.IN != 0);
 
                         const result: results.AcceptResult = result: {
                             const handle = syscall.accept(
-                                inner.socket,
-                                &inner.addr,
+                                accept.socket,
+                                &accept.addr,
                                 0,
                             ) catch |e| {
                                 const err = switch (e) {
@@ -440,8 +440,8 @@ pub fn reap(
 
                             break :result .{ .actual = .{
                                 .handle = handle,
-                                .addr = inner.addr,
-                                .kind = inner.kind,
+                                .addr = accept.addr,
+                                .kind = accept.kind,
                             } };
                         };
 
@@ -462,13 +462,13 @@ pub fn reap(
 
                         break :blk .{ .connect = result };
                     },
-                    .recv => |inner| {
+                    .recv => |recv| {
                         debug.assert(event.events & linux.EPOLL.IN != 0);
 
                         const result: results.RecvResult = result: {
                             const length = syscall.recv(
-                                inner.socket,
-                                inner.buffer,
+                                recv.socket,
+                                recv.buffer,
                                 0,
                             ) catch |e| {
                                 const err = switch (e) {
@@ -488,13 +488,13 @@ pub fn reap(
 
                         break :blk .{ .recv = result };
                     },
-                    .send => |inner| {
+                    .send => |send| {
                         debug.assert(event.events & linux.EPOLL.OUT != 0);
 
                         const result: results.SendResult = result: {
                             const length = syscall.send(
-                                inner.socket,
-                                inner.buffer,
+                                send.socket,
+                                send.buffer,
                                 0,
                             ) catch |e| {
                                 const err = switch (e) {

--- a/src/aio/IoUring.zig
+++ b/src/aio/IoUring.zig
@@ -1,6 +1,5 @@
 pub const IoUring = @This();
 
-allocator: mem.Allocator,
 inner: *linux.IoUring,
 wake_event_fd: posix.fd_t,
 wake_event_buffer: []u8,
@@ -34,8 +33,10 @@ const base_flags = blk: {
     break :blk flags;
 };
 
-pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) (mem.Allocator.Error ||
-    Errors.Init)!IoUring {
+pub fn init(
+    allocator: mem.Allocator,
+    options: AsyncIO.Options,
+) (mem.Allocator.Error || Errors.Init)!IoUring {
     // Extra job for the wake event_fd.
     const size = options.size_tasks_initial + 1;
 
@@ -93,7 +94,7 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) (mem.Allocator.E
         size,
         options.pooling,
     );
-    errdefer jobs.deinit();
+    errdefer jobs.deinit(allocator);
 
     const index = jobs.borrow_assume_unset(0);
     const item = jobs.get_ptr(index);
@@ -117,7 +118,6 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) (mem.Allocator.E
 
     return .{
         .inner = uring,
-        .allocator = allocator,
         .wake_event_fd = wake_event_fd,
         .wake_event_buffer = wake_event_buffer,
         .jobs = jobs,
@@ -125,13 +125,13 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) (mem.Allocator.E
     };
 }
 
-pub fn inner_deinit(self: *IoUring, allocator: mem.Allocator) void {
-    syscall.close(self.wake_event_fd);
-    self.inner.deinit();
-    self.jobs.deinit();
-    allocator.free(self.wake_event_buffer);
-    allocator.free(self.cqes);
-    allocator.destroy(self.inner);
+pub fn inner_deinit(io_uring: *IoUring, allocator: mem.Allocator) void {
+    syscall.close(io_uring.wake_event_fd);
+    io_uring.inner.deinit();
+    io_uring.jobs.deinit(allocator);
+    allocator.free(io_uring.wake_event_buffer);
+    allocator.free(io_uring.cqes);
+    allocator.destroy(io_uring.inner);
 }
 
 fn deinit(runner: *anyopaque, allocator: mem.Allocator) void {
@@ -141,37 +141,115 @@ fn deinit(runner: *anyopaque, allocator: mem.Allocator) void {
 
 fn queue_job(
     runner: *anyopaque,
+    allocator: mem.Allocator,
     task: usize,
     job: AsyncIO.Submission,
 ) Errors.QueueJob!void {
     const uring: *IoUring = @ptrCast(@alignCast(runner));
     (switch (job) {
-        .timer => |inner| queue_timer(uring, task, inner),
-        .open => |inner| queue_open(uring, task, inner.path, inner.flags),
-        .delete => |inner| queue_delete(uring, task, inner.path, inner.is_dir),
-        .mkdir => |inner| queue_mkdir(uring, task, inner.path, inner.mode),
-        .stat => |inner| queue_stat(uring, task, inner),
-        .read => |inner| queue_read(uring, task, inner.fd, inner.buffer, inner.offset),
-        .write => |inner| queue_write(uring, task, inner.fd, inner.buffer, inner.offset),
-        .close => |inner| queue_close(uring, task, inner),
-        .accept => |inner| queue_accept(uring, task, inner.socket, inner.kind),
-        .connect => |inner| queue_connect(uring, task, inner.socket, inner.addr, inner.kind),
-        .recv => |inner| queue_recv(uring, task, inner.socket, inner.buffer),
-        .send => |inner| queue_send(uring, task, inner.socket, inner.buffer),
+        .timer => |inner| queue_timer(
+            uring,
+            allocator,
+            task,
+            inner,
+        ),
+        .open => |inner| queue_open(
+            uring,
+            allocator,
+            task,
+            inner.path,
+            inner.flags,
+        ),
+        .delete => |inner| queue_delete(
+            uring,
+            allocator,
+            task,
+            inner.path,
+            inner.is_dir,
+        ),
+        .mkdir => |inner| queue_mkdir(
+            uring,
+            allocator,
+            task,
+            inner.path,
+            inner.mode,
+        ),
+        .stat => |inner| queue_stat(
+            uring,
+            allocator,
+            task,
+            inner,
+        ),
+        .read => |inner| queue_read(
+            uring,
+            allocator,
+            task,
+            inner.fd,
+            inner.buffer,
+            inner.offset,
+        ),
+        .write => |inner| queue_write(
+            uring,
+            allocator,
+            task,
+            inner.fd,
+            inner.buffer,
+            inner.offset,
+        ),
+        .close => |inner| queue_close(
+            uring,
+            allocator,
+            task,
+            inner,
+        ),
+        .accept => |inner| queue_accept(
+            uring,
+            allocator,
+            task,
+            inner.socket,
+            inner.kind,
+        ),
+        .connect => |inner| queue_connect(
+            uring,
+            allocator,
+            task,
+            inner.socket,
+            inner.addr,
+            inner.kind,
+        ),
+        .recv => |inner| queue_recv(
+            uring,
+            allocator,
+            task,
+            inner.socket,
+            inner.buffer,
+        ),
+        .send => |inner| queue_send(
+            uring,
+            allocator,
+            task,
+            inner.socket,
+            inner.buffer,
+        ),
     }) catch |e| switch (e) {
         error.SubmissionQueueFull => {
             try submit(runner);
-            try queue_job(runner, task, job);
+            try queue_job(runner, allocator, task, job);
         },
         else => |err| return err,
     };
 }
 
-fn queue_timer(self: *IoUring, task: usize, duration: Io.Duration) Error!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
+fn queue_timer(
+    io_uring: *IoUring,
+    allocator: mem.Allocator,
+    task: usize,
+    duration: Io.Duration,
+) Error!void {
+    const index = try io_uring.jobs.borrow_hint(allocator, task);
+    errdefer io_uring.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = io_uring.jobs.get_ptr(index);
     item.job = .{
         .index = index,
         .task = task,
@@ -179,8 +257,8 @@ fn queue_timer(self: *IoUring, task: usize, duration: Io.Duration) Error!void {
     };
 
     // TODO: make copierble types none pointers
-    const timespec_ptr = try self.allocator.create(linux.kernel_timespec);
-    errdefer self.allocator.destroy(timespec_ptr);
+    const timespec_ptr = try allocator.create(linux.kernel_timespec);
+    errdefer allocator.destroy(timespec_ptr);
 
     timespec_ptr.* = .{
         .sec = @intCast(@divFloor(duration.nanoseconds, std.time.ns_per_s)),
@@ -188,19 +266,25 @@ fn queue_timer(self: *IoUring, task: usize, duration: Io.Duration) Error!void {
     };
     item.timespec = timespec_ptr;
 
-    _ = try self.inner.timeout(index, timespec_ptr, 0, 0);
+    _ = try io_uring.inner.timeout(
+        index,
+        timespec_ptr,
+        0,
+        0,
+    );
 }
 
 fn queue_open(
-    self: *IoUring,
+    io_uring: *IoUring,
+    allocator: mem.Allocator,
     task: usize,
     path: fs.Path,
     flags: AsyncIO.OpenFlags,
 ) Error!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
+    const index = try io_uring.jobs.borrow_hint(allocator, task);
+    errdefer io_uring.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = io_uring.jobs.get_ptr(index);
     item.job = .{
         .index = index,
         .type = .{
@@ -237,14 +321,14 @@ fn queue_open(
     const perms = flags.perms orelse 0;
 
     switch (path) {
-        .rel => |inner| _ = try self.inner.openat(
+        .rel => |inner| _ = try io_uring.inner.openat(
             index,
             inner.dir,
             inner.path.ptr,
             o_flags,
             @intCast(perms),
         ),
-        .abs => |inner| _ = try self.inner.openat(
+        .abs => |inner| _ = try io_uring.inner.openat(
             index,
             posix.AT.FDCWD,
             inner.ptr,
@@ -254,11 +338,17 @@ fn queue_open(
     }
 }
 
-fn queue_delete(self: *IoUring, task: usize, path: fs.Path, is_dir: bool) Error!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
+fn queue_delete(
+    io_uring: *IoUring,
+    allocator: mem.Allocator,
+    task: usize,
+    path: fs.Path,
+    is_dir: bool,
+) Error!void {
+    const index = try io_uring.jobs.borrow_hint(allocator, task);
+    errdefer io_uring.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = io_uring.jobs.get_ptr(index);
     item.job = .{
         .index = index,
         .type = .{
@@ -273,16 +363,22 @@ fn queue_delete(self: *IoUring, task: usize, path: fs.Path, is_dir: bool) Error!
     const mode: u32 = if (is_dir) posix.AT.REMOVEDIR else 0;
 
     switch (path) {
-        .rel => |inner| _ = try self.inner.unlinkat(index, inner.dir, inner.path.ptr, mode),
-        .abs => |inner| _ = try self.inner.unlinkat(index, posix.AT.FDCWD, inner.ptr, mode),
+        .rel => |inner| _ = try io_uring.inner.unlinkat(index, inner.dir, inner.path.ptr, mode),
+        .abs => |inner| _ = try io_uring.inner.unlinkat(index, posix.AT.FDCWD, inner.ptr, mode),
     }
 }
 
-fn queue_mkdir(self: *IoUring, task: usize, path: fs.Path, mode: isize) Error!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
+fn queue_mkdir(
+    io_uring: *IoUring,
+    allocator: mem.Allocator,
+    task: usize,
+    path: fs.Path,
+    mode: isize,
+) Error!void {
+    const index = try io_uring.jobs.borrow_hint(allocator, task);
+    errdefer io_uring.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = io_uring.jobs.get_ptr(index);
     item.job = .{
         .index = index,
         .type = .{
@@ -295,27 +391,42 @@ fn queue_mkdir(self: *IoUring, task: usize, path: fs.Path, mode: isize) Error!vo
     };
 
     switch (path) {
-        .rel => |inner| _ = try self.inner.mkdirat(index, inner.dir, inner.path.ptr, @intCast(mode)),
-        .abs => |inner| _ = try self.inner.mkdirat(index, posix.AT.FDCWD, inner.ptr, @intCast(mode)),
+        .rel => |inner| _ = try io_uring.inner.mkdirat(
+            index,
+            inner.dir,
+            inner.path.ptr,
+            @intCast(mode),
+        ),
+        .abs => |inner| _ = try io_uring.inner.mkdirat(
+            index,
+            posix.AT.FDCWD,
+            inner.ptr,
+            @intCast(mode),
+        ),
     }
 }
 
-fn queue_stat(self: *IoUring, task: usize, fd: posix.fd_t) Error!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
+fn queue_stat(
+    io_uring: *IoUring,
+    allocator: mem.Allocator,
+    task: usize,
+    fd: posix.fd_t,
+) Error!void {
+    const index = try io_uring.jobs.borrow_hint(allocator, task);
+    errdefer io_uring.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = io_uring.jobs.get_ptr(index);
     item.job = .{
         .index = index,
         .type = .{ .stat = fd },
         .task = task,
     };
 
-    const statx_ptr = try self.allocator.create(linux.Statx);
-    errdefer self.allocator.destroy(statx_ptr);
+    const statx_ptr = try allocator.create(linux.Statx);
+    errdefer allocator.destroy(statx_ptr);
     item.statx = statx_ptr;
 
-    _ = try self.inner.statx(
+    _ = try io_uring.inner.statx(
         index,
         fd,
         "",
@@ -325,13 +436,21 @@ fn queue_stat(self: *IoUring, task: usize, fd: posix.fd_t) Error!void {
     );
 }
 
-fn queue_read(self: *IoUring, task: usize, fd: posix.fd_t, buffer: []u8, offset: ?usize) Error!void {
+fn queue_read(
+    io_uring: *IoUring,
+    allocator: mem.Allocator,
+    task: usize,
+    fd: posix.fd_t,
+    buffer: []u8,
+    offset: ?usize,
+) Error!void {
+    const index = try io_uring.jobs.borrow_hint(allocator, task);
+    errdefer io_uring.jobs.release(index);
+
     // If we don't have an offset, set it as -1.
     const real_offset: usize = if (offset) |o| o else @bitCast(@as(isize, -1));
 
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
-    const item = self.jobs.get_ptr(index);
+    const item = io_uring.jobs.get_ptr(index);
     item.job = .{
         .index = index,
         .type = .{
@@ -344,16 +463,32 @@ fn queue_read(self: *IoUring, task: usize, fd: posix.fd_t, buffer: []u8, offset:
         .task = task,
     };
 
-    _ = try self.inner.read(index, fd, .{ .buffer = buffer }, real_offset);
+    _ = try io_uring.inner.read(
+        index,
+        fd,
+        .{ .buffer = buffer },
+        real_offset,
+    );
 }
 
-fn queue_write(self: *IoUring, task: usize, fd: posix.fd_t, buffer: []const u8, offset: ?usize) Error!void {
+fn queue_write(
+    io_uring: *IoUring,
+    allocator: mem.Allocator,
+    task: usize,
+    fd: posix.fd_t,
+    buffer: []const u8,
+    offset: ?usize,
+) Error!void {
+    const index = io_uring.jobs.borrow_hint(
+        allocator,
+        task,
+    ) catch @panic("OOM");
+    errdefer io_uring.jobs.release(index);
+
     // If we don't have an offset, set it as -1.
     const real_offset: usize = if (offset) |o| o else @bitCast(@as(isize, -1));
 
-    const index = self.jobs.borrow_hint(task) catch @panic("OOM");
-    errdefer self.jobs.release(index);
-    const item = self.jobs.get_ptr(index);
+    const item = io_uring.jobs.get_ptr(index);
     item.job = .{
         .index = index,
         .type = .{
@@ -366,33 +501,50 @@ fn queue_write(self: *IoUring, task: usize, fd: posix.fd_t, buffer: []const u8, 
         .task = task,
     };
 
-    _ = try self.inner.write(index, fd, buffer, real_offset);
+    _ = try io_uring.inner.write(
+        index,
+        fd,
+        buffer,
+        real_offset,
+    );
 }
 
-fn queue_close(self: *IoUring, task: usize, fd: posix.fd_t) Error!void {
-    const index = self.jobs.borrow_hint(task) catch @panic("OOM");
-    errdefer self.jobs.release(index);
+fn queue_close(
+    io_uring: *IoUring,
+    allocator: mem.Allocator,
+    task: usize,
+    fd: posix.fd_t,
+) Error!void {
+    const index = io_uring.jobs.borrow_hint(
+        allocator,
+        task,
+    ) catch @panic("OOM");
+    errdefer io_uring.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = io_uring.jobs.get_ptr(index);
     item.job = .{
         .index = index,
         .type = .{ .close = fd },
         .task = task,
     };
 
-    _ = try self.inner.close(index, fd);
+    _ = try io_uring.inner.close(index, fd);
 }
 
 fn queue_accept(
-    self: *IoUring,
+    io_uring: *IoUring,
+    allocator: mem.Allocator,
     task: usize,
     socket: posix.socket_t,
     kind: net.Socket.Kind,
 ) Error!void {
-    const index = self.jobs.borrow_hint(task) catch @panic("OOM");
-    errdefer self.jobs.release(index);
+    const index = io_uring.jobs.borrow_hint(
+        allocator,
+        task,
+    ) catch @panic("OOM");
+    errdefer io_uring.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = io_uring.jobs.get_ptr(index);
     item.job = .{
         .index = index,
         .type = .{
@@ -406,7 +558,7 @@ fn queue_accept(
     };
     var sockaddr, var socklen = item.job.type.accept.addr.toPosix();
 
-    _ = try self.inner.accept(
+    _ = try io_uring.inner.accept(
         index,
         socket,
         &sockaddr,
@@ -416,16 +568,20 @@ fn queue_accept(
 }
 
 fn queue_connect(
-    self: *IoUring,
+    io_uring: *IoUring,
+    allocator: mem.Allocator,
     task: usize,
     socket: posix.socket_t,
     addr: net.Socket.Address,
     kind: net.Socket.Kind,
 ) Error!void {
-    const index = self.jobs.borrow_hint(task) catch @panic("OOM");
-    errdefer self.jobs.release(index);
+    const index = io_uring.jobs.borrow_hint(
+        allocator,
+        task,
+    ) catch @panic("OOM");
+    errdefer io_uring.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = io_uring.jobs.get_ptr(index);
     item.job = .{
         .index = index,
         .type = .{
@@ -439,7 +595,7 @@ fn queue_connect(
     };
     const sockaddr, const socklen = item.job.type.connect.addr.toPosix();
 
-    _ = try self.inner.connect(
+    _ = try io_uring.inner.connect(
         index,
         socket,
         &sockaddr,
@@ -448,14 +604,19 @@ fn queue_connect(
 }
 
 fn queue_recv(
-    self: *IoUring,
+    io_uring: *IoUring,
+    allocator: mem.Allocator,
     task: usize,
     socket: posix.socket_t,
     buffer: []u8,
 ) Error!void {
-    const index = self.jobs.borrow_hint(task) catch @panic("OOM");
-    errdefer self.jobs.release(index);
-    const item = self.jobs.get_ptr(index);
+    const index = io_uring.jobs.borrow_hint(
+        allocator,
+        task,
+    ) catch @panic("OOM");
+    errdefer io_uring.jobs.release(index);
+
+    const item = io_uring.jobs.get_ptr(index);
     item.job = .{
         .index = index,
         .type = .{
@@ -467,14 +628,25 @@ fn queue_recv(
         .task = task,
     };
 
-    _ = try self.inner.recv(index, socket, .{ .buffer = buffer }, 0);
+    _ = try io_uring.inner.recv(
+        index,
+        socket,
+        .{ .buffer = buffer },
+        0,
+    );
 }
 
-fn queue_send(self: *IoUring, task: usize, socket: posix.socket_t, buffer: []const u8) Error!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
+fn queue_send(
+    io_uring: *IoUring,
+    allocator: mem.Allocator,
+    task: usize,
+    socket: posix.socket_t,
+    buffer: []const u8,
+) Error!void {
+    const index = try io_uring.jobs.borrow_hint(allocator, task);
+    errdefer io_uring.jobs.release(index);
 
-    const item = self.jobs.get_ptr(index);
+    const item = io_uring.jobs.get_ptr(index);
     item.job = .{
         .index = index,
         .type = .{
@@ -486,26 +658,26 @@ fn queue_send(self: *IoUring, task: usize, socket: posix.socket_t, buffer: []con
         .task = task,
     };
 
-    _ = try self.inner.send(index, socket, buffer, 0);
+    _ = try io_uring.inner.send(index, socket, buffer, 0);
 }
 
-inline fn queue_wake(self: *IoUring) Error!void {
-    if (self.wake_event_fd == cross.fd.INVALID_FD) return;
+inline fn queue_wake(io_uring: *IoUring, alloator: mem.Allocator) Error!void {
+    const index = try io_uring.jobs.borrow(alloator);
+    errdefer io_uring.jobs.release(index);
 
-    const index = try self.jobs.borrow();
-    errdefer self.jobs.release(index);
+    if (io_uring.wake_event_fd == cross.fd.INVALID_FD) return;
 
-    const item = self.jobs.get_ptr(index);
+    const item = io_uring.jobs.get_ptr(index);
     item.job = .{
         .index = index,
         .type = .wake,
         .task = undefined,
     };
 
-    _ = try self.inner.read(
+    _ = try io_uring.inner.read(
         index,
-        self.wake_event_fd,
-        .{ .buffer = self.wake_event_buffer },
+        io_uring.wake_event_fd,
+        .{ .buffer = io_uring.wake_event_buffer },
         0,
     );
 }
@@ -530,6 +702,7 @@ fn submit(runner: *anyopaque) Errors.Submit!void {
 
 fn reap(
     runner: *anyopaque,
+    allocator: mem.Allocator,
     completions: []results.Completion,
     wait: bool,
 ) Errors.Reap![]results.Completion {
@@ -560,11 +733,11 @@ fn reap(
             }
             switch (job.type) {
                 .wake => {
-                    try uring.queue_wake();
+                    try uring.queue_wake(allocator);
                     break :blk .wake;
                 },
                 .timer => {
-                    defer uring.allocator.destroy(job_with_data.timespec);
+                    defer allocator.destroy(job_with_data.timespec);
                     break :blk .none;
                 },
                 .close => break :blk .close,
@@ -830,7 +1003,7 @@ fn reap(
                     break :blk .{ .write = result };
                 },
                 .stat => {
-                    defer uring.allocator.destroy(job_with_data.statx);
+                    defer allocator.destroy(job_with_data.statx);
 
                     if (cqe.res == 0) {
                         const statx = job_with_data.statx;
@@ -881,9 +1054,9 @@ fn reap(
     return completions[0..count];
 }
 
-pub fn to_async(self: *IoUring) AsyncIO {
+pub fn to_async(io_uring: *IoUring) AsyncIO {
     return .{
-        .runner = self,
+        .runner = io_uring,
         .features = .all(),
         .vtable = .{
             .queue_job = queue_job,
@@ -934,7 +1107,7 @@ pub const Errors = struct {
         // described by `addr` and `len` is not within the buffer registered at `buf_index`:
         BufferInvalid,
         RingShuttingDown,
-        // The kernel believes our `self.fd` does not refer to an io_uring instance,
+        // The kernel believes our `io_uring.fd` does not refer to an io_uring instance,
         // or the opcode is valid but not supported by this kernel (more likely):
         OpcodeNotSupported,
         // The thread submitting the work is invalid. This may occur if IORING_ENTER_GETEVENTS

--- a/src/aio/IoUring.zig
+++ b/src/aio/IoUring.zig
@@ -63,10 +63,13 @@ pub fn init(
 
             // Initialize using the WQ from the parent ring.
             const flags: u32 = base_flags | linux.IORING_SETUP_ATTACH_WQ;
-            var params = mem.zeroInit(linux.io_uring_params, .{
-                .flags = flags,
-                .wq_fd = @as(u32, @intCast(parent_uring.inner.fd)),
-            });
+            var params = mem.zeroInit(
+                linux.io_uring_params,
+                .{
+                    .flags = flags,
+                    .wq_fd = @as(u32, @intCast(parent_uring.inner.fd)),
+                },
+            );
 
             const uring = try allocator.create(linux.IoUring);
             errdefer allocator.destroy(uring);
@@ -147,85 +150,74 @@ fn queue_job(
 ) Errors.QueueJob!void {
     const uring: *IoUring = @ptrCast(@alignCast(runner));
     (switch (job) {
-        .timer => |inner| queue_timer(
-            uring,
+        .timer => |inner| uring.queue_timer(
             allocator,
             task,
             inner,
         ),
-        .open => |inner| queue_open(
-            uring,
+        .open => |inner| uring.queue_open(
             allocator,
             task,
             inner.path,
             inner.flags,
         ),
-        .delete => |inner| queue_delete(
-            uring,
+        .delete => |inner| uring.queue_delete(
             allocator,
             task,
             inner.path,
             inner.is_dir,
         ),
-        .mkdir => |inner| queue_mkdir(
-            uring,
+        .mkdir => |inner| uring.queue_mkdir(
             allocator,
             task,
             inner.path,
             inner.mode,
         ),
-        .stat => |inner| queue_stat(
-            uring,
+        .stat => |inner| uring.queue_stat(
             allocator,
             task,
             inner,
         ),
-        .read => |inner| queue_read(
-            uring,
+        .read => |inner| uring.queue_read(
             allocator,
             task,
             inner.fd,
             inner.buffer,
             inner.offset,
         ),
-        .write => |inner| queue_write(
-            uring,
+        .write => |inner| uring.queue_write(
             allocator,
             task,
             inner.fd,
             inner.buffer,
             inner.offset,
         ),
-        .close => |inner| queue_close(
-            uring,
+        .close => |inner| uring.queue_close(
             allocator,
             task,
             inner,
         ),
-        .accept => |inner| queue_accept(
-            uring,
+        .accept => |inner| uring.queue_accept(
             allocator,
             task,
             inner.socket,
             inner.kind,
         ),
-        .connect => |inner| queue_connect(
-            uring,
+        .connect => |inner| uring.queue_connect(
             allocator,
             task,
             inner.socket,
             inner.addr,
             inner.kind,
         ),
-        .recv => |inner| queue_recv(
+        .recv => |inner| uring.queue_recv(
             uring,
             allocator,
             task,
             inner.socket,
             inner.buffer,
         ),
-        .send => |inner| queue_send(
-            uring,
+        .send => |inner| uring.queue_send(
             allocator,
             task,
             inner.socket,
@@ -363,8 +355,18 @@ fn queue_delete(
     const mode: u32 = if (is_dir) posix.AT.REMOVEDIR else 0;
 
     switch (path) {
-        .rel => |inner| _ = try io_uring.inner.unlinkat(index, inner.dir, inner.path.ptr, mode),
-        .abs => |inner| _ = try io_uring.inner.unlinkat(index, posix.AT.FDCWD, inner.ptr, mode),
+        .rel => |rel| _ = try io_uring.inner.unlinkat(
+            index,
+            rel.dir,
+            rel.path.ptr,
+            mode,
+        ),
+        .abs => |abs| _ = try io_uring.inner.unlinkat(
+            index,
+            posix.AT.FDCWD,
+            abs.ptr,
+            mode,
+        ),
     }
 }
 
@@ -391,16 +393,16 @@ fn queue_mkdir(
     };
 
     switch (path) {
-        .rel => |inner| _ = try io_uring.inner.mkdirat(
+        .rel => |rel| _ = try io_uring.inner.mkdirat(
             index,
-            inner.dir,
-            inner.path.ptr,
+            rel.dir,
+            rel.path.ptr,
             @intCast(mode),
         ),
-        .abs => |inner| _ = try io_uring.inner.mkdirat(
+        .abs => |abs| _ = try io_uring.inner.mkdirat(
             index,
             posix.AT.FDCWD,
-            inner.ptr,
+            abs.ptr,
             @intCast(mode),
         ),
     }
@@ -711,12 +713,13 @@ fn reap(
     const uring_nr: u32 = if (wait) 1 else 0;
 
     const count = while (true) {
-        break uring.inner.copy_cqes(uring.cqes[0..], uring_nr) catch |e| {
-            switch (e) {
-                error.SignalInterrupt => continue,
-                else => |err| return err,
-            }
-        };
+        break uring.inner.copy_cqes(uring.cqes[0..], uring_nr) catch |e|
+            {
+                switch (e) {
+                    error.SignalInterrupt => continue,
+                    else => |err| return err,
+                }
+            };
     };
 
     for (uring.cqes[0..count], 0..) |cqe, i| {
@@ -759,15 +762,33 @@ fn reap(
                     const result: results.AcceptResult = result: {
                         const e: linux.E = @fromBackingInt(@intCast(-cqe.res));
                         break :result switch (e) {
-                            .AGAIN => .{ .err = AcceptError.WouldBlock },
-                            .BADF => .{ .err = AcceptError.InvalidFd },
-                            .CONNABORTED => .{ .err = AcceptError.ConnectionAborted },
-                            .FAULT => .{ .err = AcceptError.InvalidAddress },
-                            .INVAL => .{ .err = AcceptError.NotListening },
-                            .MFILE => .{ .err = AcceptError.ProcessFdQuotaExceeded },
-                            .NFILE => .{ .err = AcceptError.SystemFdQuotaExceeded },
-                            .NOBUFS, .NOMEM => .{ .err = AcceptError.OutOfMemory },
-                            else => .{ .err = AcceptError.Unexpected },
+                            .AGAIN => .{
+                                .err = AcceptError.WouldBlock,
+                            },
+                            .BADF => .{
+                                .err = AcceptError.InvalidFd,
+                            },
+                            .CONNABORTED => .{
+                                .err = AcceptError.ConnectionAborted,
+                            },
+                            .FAULT => .{
+                                .err = AcceptError.InvalidAddress,
+                            },
+                            .INVAL => .{
+                                .err = AcceptError.NotListening,
+                            },
+                            .MFILE => .{
+                                .err = AcceptError.ProcessFdQuotaExceeded,
+                            },
+                            .NFILE => .{
+                                .err = AcceptError.SystemFdQuotaExceeded,
+                            },
+                            .NOBUFS, .NOMEM => .{
+                                .err = AcceptError.OutOfMemory,
+                            },
+                            else => .{
+                                .err = AcceptError.Unexpected,
+                            },
                         };
                     };
 
@@ -781,22 +802,48 @@ fn reap(
                     const result: results.ConnectResult = result: {
                         const e: linux.E = @fromBackingInt(@intCast(-cqe.res));
                         break :result switch (e) {
-                            .ACCES, .PERM => .{ .err = ConnectError.AccessDenied },
-                            .ADDRINUSE => .{ .err = ConnectError.AddressInUse },
-                            .ADDRNOTAVAIL => .{ .err = ConnectError.AddressNotAvailable },
-                            .AFNOSUPPORT => .{ .err = ConnectError.AddressFamilyNotSupported },
+                            .ACCES, .PERM => .{
+                                .err = ConnectError.AccessDenied,
+                            },
+                            .ADDRINUSE => .{
+                                .err = ConnectError.AddressInUse,
+                            },
+                            .ADDRNOTAVAIL => .{
+                                .err = ConnectError.AddressNotAvailable,
+                            },
+                            .AFNOSUPPORT => .{
+                                .err = ConnectError.AddressFamilyNotSupported,
+                            },
                             .AGAIN, .ALREADY, .INPROGRESS => .{
                                 .err = ConnectError.WouldBlock,
                             },
-                            .BADF => .{ .err = ConnectError.InvalidFd },
-                            .CONNREFUSED => .{ .err = ConnectError.ConnectionRefused },
-                            .FAULT => .{ .err = ConnectError.InvalidAddress },
-                            .ISCONN => .{ .err = ConnectError.AlreadyConnected },
-                            .NETUNREACH => .{ .err = ConnectError.NetworkUnreachable },
-                            .NOTSOCK => .{ .err = ConnectError.NotASocket },
-                            .PROTOTYPE => .{ .err = ConnectError.ProtocolFamilyNotSupported },
-                            .TIMEDOUT => .{ .err = ConnectError.TimedOut },
-                            else => .{ .err = ConnectError.Unexpected },
+                            .BADF => .{
+                                .err = ConnectError.InvalidFd,
+                            },
+                            .CONNREFUSED => .{
+                                .err = ConnectError.ConnectionRefused,
+                            },
+                            .FAULT => .{
+                                .err = ConnectError.InvalidAddress,
+                            },
+                            .ISCONN => .{
+                                .err = ConnectError.AlreadyConnected,
+                            },
+                            .NETUNREACH => .{
+                                .err = ConnectError.NetworkUnreachable,
+                            },
+                            .NOTSOCK => .{
+                                .err = ConnectError.NotASocket,
+                            },
+                            .PROTOTYPE => .{
+                                .err = ConnectError.ProtocolFamilyNotSupported,
+                            },
+                            .TIMEDOUT => .{
+                                .err = ConnectError.TimedOut,
+                            },
+                            else => .{
+                                .err = ConnectError.Unexpected,
+                            },
                         };
                     };
 
@@ -816,12 +863,24 @@ fn reap(
                         const e: linux.E = @fromBackingInt(@intCast(-cqe.res));
                         break :result switch (e) {
                             .NOTSOCK, .INVAL, .FAULT, .BADF => unreachable,
-                            .AGAIN => .{ .err = RecvError.WouldBlock },
-                            .CONNRESET => .{ .err = RecvError.Closed },
-                            .CONNREFUSED => .{ .err = RecvError.ConnectionRefused },
-                            .NOMEM => .{ .err = RecvError.SystemResources },
-                            .NOTCONN => .{ .err = RecvError.SocketNotConnected },
-                            else => .{ .err = RecvError.Unexpected },
+                            .AGAIN => .{
+                                .err = RecvError.WouldBlock,
+                            },
+                            .CONNRESET => .{
+                                .err = RecvError.Closed,
+                            },
+                            .CONNREFUSED => .{
+                                .err = RecvError.ConnectionRefused,
+                            },
+                            .NOMEM => .{
+                                .err = RecvError.SystemResources,
+                            },
+                            .NOTCONN => .{
+                                .err = RecvError.SocketNotConnected,
+                            },
+                            else => .{
+                                .err = RecvError.Unexpected,
+                            },
                         };
                     };
 
@@ -841,39 +900,73 @@ fn reap(
                             .INVAL,
                             .DESTADDRREQ,
                             => unreachable,
-                            .BADF => .{ .err = SendError.InvalidFd },
-                            .ACCES => .{ .err = SendError.AccessDenied },
-                            .AGAIN => .{ .err = SendError.WouldBlock },
-                            .ALREADY => .{ .err = SendError.FastOpenAlreadyInProgress },
-                            .CONNRESET, .PIPE => .{ .err = SendError.Closed },
-                            .MSGSIZE => .{ .err = SendError.MessageOversize },
+                            .BADF => .{
+                                .err = SendError.InvalidFd,
+                            },
+                            .ACCES => .{
+                                .err = SendError.AccessDenied,
+                            },
+                            .AGAIN => .{
+                                .err = SendError.WouldBlock,
+                            },
+                            .ALREADY => .{
+                                .err = SendError.FastOpenAlreadyInProgress,
+                            },
+                            .CONNRESET, .PIPE => .{
+                                .err = SendError.Closed,
+                            },
+                            .MSGSIZE => .{
+                                .err = SendError.MessageOversize,
+                            },
                             .NOBUFS,
                             .NOMEM,
                             => .{
                                 .err = SendError.SystemResources,
                             },
-                            else => .{ .err = SendError.Unexpected },
+                            else => .{
+                                .err = SendError.Unexpected,
+                            },
                         };
                     };
 
                     break :blk .{ .send = result };
                 },
                 .mkdir => {
-                    if (cqe.res == 0) break :blk .{ .mkdir = .{ .actual = {} } };
+                    if (cqe.res == 0) break :blk .{
+                        .mkdir = .{ .actual = {} },
+                    };
 
                     const MkdirError = results.MkdirError;
                     const result: results.MkdirResult = result: {
                         const e: linux.E = @fromBackingInt(@intCast(-cqe.res));
                         break :result switch (e) {
-                            .ACCES => .{ .err = MkdirError.AccessDenied },
-                            .EXIST => .{ .err = MkdirError.AlreadyExists },
-                            .LOOP, .MLINK => .{ .err = MkdirError.Loop },
-                            .NAMETOOLONG => .{ .err = MkdirError.NameTooLong },
-                            .NOENT => .{ .err = MkdirError.NotFound },
-                            .NOSPC => .{ .err = MkdirError.NoSpace },
-                            .NOTDIR => .{ .err = MkdirError.NotADirectory },
-                            .ROFS => .{ .err = MkdirError.ReadOnlyFileSystem },
-                            else => .{ .err = MkdirError.Unexpected },
+                            .ACCES => .{
+                                .err = MkdirError.AccessDenied,
+                            },
+                            .EXIST => .{
+                                .err = MkdirError.AlreadyExists,
+                            },
+                            .LOOP, .MLINK => .{
+                                .err = MkdirError.Loop,
+                            },
+                            .NAMETOOLONG => .{
+                                .err = MkdirError.NameTooLong,
+                            },
+                            .NOENT => .{
+                                .err = MkdirError.NotFound,
+                            },
+                            .NOSPC => .{
+                                .err = MkdirError.NoSpace,
+                            },
+                            .NOTDIR => .{
+                                .err = MkdirError.NotADirectory,
+                            },
+                            .ROFS => .{
+                                .err = MkdirError.ReadOnlyFileSystem,
+                            },
+                            else => .{
+                                .err = MkdirError.Unexpected,
+                            },
                         };
                     };
 
@@ -882,10 +975,18 @@ fn reap(
                 .open => |inner| {
                     if (cqe.res >= 0) switch (inner.kind) {
                         .file => break :blk .{
-                            .open = .{ .actual = .{ .file = .{ .handle = @intCast(cqe.res) } } },
+                            .open = .{
+                                .actual = .{ .file = .{
+                                    .handle = @intCast(cqe.res),
+                                } },
+                            },
                         },
                         .dir => break :blk .{
-                            .open = .{ .actual = .{ .dir = .{ .handle = @intCast(cqe.res) } } },
+                            .open = .{
+                                .actual = .{ .dir = .{
+                                    .handle = @intCast(cqe.res),
+                                } },
+                            },
                         },
                     };
 
@@ -893,29 +994,75 @@ fn reap(
                     const result: results.InnerOpenResult = result: {
                         const e: linux.E = @fromBackingInt(@intCast(-cqe.res));
                         break :result switch (e) {
-                            .ACCES, .PERM => .{ .err = OpenError.AccessDenied },
-                            .BADF => .{ .err = OpenError.InvalidFd },
-                            .BUSY => .{ .err = OpenError.Busy },
-                            .DQUOT => .{ .err = OpenError.DiskQuotaExceeded },
-                            .EXIST => .{ .err = OpenError.AlreadyExists },
-                            .FAULT => .{ .err = OpenError.InvalidAddress },
-                            .FBIG, .OVERFLOW => .{ .err = OpenError.FileTooBig },
-                            .INVAL => .{ .err = OpenError.InvalidArguments },
-                            .ISDIR => .{ .err = OpenError.IsDirectory },
-                            .LOOP => .{ .err = OpenError.Loop },
-                            .MFILE => .{ .err = OpenError.ProcessFdQuotaExceeded },
-                            .NAMETOOLONG => .{ .err = OpenError.NameTooLong },
-                            .NFILE => .{ .err = OpenError.SystemFdQuotaExceeded },
-                            .NODEV, .NXIO => .{ .err = OpenError.DeviceNotFound },
-                            .NOENT => .{ .err = OpenError.NotFound },
-                            .NOMEM => .{ .err = OpenError.OutOfMemory },
-                            .NOSPC => .{ .err = OpenError.NoSpace },
-                            .NOTDIR => .{ .err = OpenError.NotADirectory },
-                            .OPNOTSUPP => .{ .err = OpenError.OperationNotSupported },
-                            .ROFS => .{ .err = OpenError.ReadOnlyFileSystem },
-                            .TXTBSY => .{ .err = OpenError.FileLocked },
-                            .AGAIN => .{ .err = OpenError.WouldBlock },
-                            else => .{ .err = OpenError.Unexpected },
+                            .ACCES, .PERM => .{
+                                .err = OpenError.AccessDenied,
+                            },
+                            .BADF => .{
+                                .err = OpenError.InvalidFd,
+                            },
+                            .BUSY => .{
+                                .err = OpenError.Busy,
+                            },
+                            .DQUOT => .{
+                                .err = OpenError.DiskQuotaExceeded,
+                            },
+                            .EXIST => .{
+                                .err = OpenError.AlreadyExists,
+                            },
+                            .FAULT => .{
+                                .err = OpenError.InvalidAddress,
+                            },
+                            .FBIG, .OVERFLOW => .{
+                                .err = OpenError.FileTooBig,
+                            },
+                            .INVAL => .{
+                                .err = OpenError.InvalidArguments,
+                            },
+                            .ISDIR => .{
+                                .err = OpenError.IsDirectory,
+                            },
+                            .LOOP => .{
+                                .err = OpenError.Loop,
+                            },
+                            .MFILE => .{
+                                .err = OpenError.ProcessFdQuotaExceeded,
+                            },
+                            .NAMETOOLONG => .{
+                                .err = OpenError.NameTooLong,
+                            },
+                            .NFILE => .{
+                                .err = OpenError.SystemFdQuotaExceeded,
+                            },
+                            .NODEV, .NXIO => .{
+                                .err = OpenError.DeviceNotFound,
+                            },
+                            .NOENT => .{
+                                .err = OpenError.NotFound,
+                            },
+                            .NOMEM => .{
+                                .err = OpenError.OutOfMemory,
+                            },
+                            .NOSPC => .{
+                                .err = OpenError.NoSpace,
+                            },
+                            .NOTDIR => .{
+                                .err = OpenError.NotADirectory,
+                            },
+                            .OPNOTSUPP => .{
+                                .err = OpenError.OperationNotSupported,
+                            },
+                            .ROFS => .{
+                                .err = OpenError.ReadOnlyFileSystem,
+                            },
+                            .TXTBSY => .{
+                                .err = OpenError.FileLocked,
+                            },
+                            .AGAIN => .{
+                                .err = OpenError.WouldBlock,
+                            },
+                            else => .{
+                                .err = OpenError.Unexpected,
+                            },
                         };
                     };
 
@@ -929,22 +1076,52 @@ fn reap(
                         const e: linux.E = @fromBackingInt(@intCast(-cqe.res));
                         break :result switch (e) {
                             // unlink
-                            .ACCES => .{ .err = DeleteError.AccessDenied },
-                            .BUSY => .{ .err = DeleteError.Busy },
-                            .FAULT => .{ .err = DeleteError.InvalidAddress },
-                            .IO => .{ .err = DeleteError.IoError },
-                            .ISDIR, .PERM => .{ .err = DeleteError.IsDirectory },
-                            .LOOP => .{ .err = DeleteError.Loop },
-                            .NAMETOOLONG => .{ .err = DeleteError.NameTooLong },
-                            .NOENT => .{ .err = DeleteError.NotFound },
-                            .NOMEM => .{ .err = DeleteError.OutOfMemory },
-                            .NOTDIR => .{ .err = DeleteError.IsNotDirectory },
-                            .ROFS => .{ .err = DeleteError.ReadOnlyFileSystem },
-                            .BADF => .{ .err = DeleteError.InvalidFd },
+                            .ACCES => .{
+                                .err = DeleteError.AccessDenied,
+                            },
+                            .BUSY => .{
+                                .err = DeleteError.Busy,
+                            },
+                            .FAULT => .{
+                                .err = DeleteError.InvalidAddress,
+                            },
+                            .IO => .{
+                                .err = DeleteError.IoError,
+                            },
+                            .ISDIR, .PERM => .{
+                                .err = DeleteError.IsDirectory,
+                            },
+                            .LOOP => .{
+                                .err = DeleteError.Loop,
+                            },
+                            .NAMETOOLONG => .{
+                                .err = DeleteError.NameTooLong,
+                            },
+                            .NOENT => .{
+                                .err = DeleteError.NotFound,
+                            },
+                            .NOMEM => .{
+                                .err = DeleteError.OutOfMemory,
+                            },
+                            .NOTDIR => .{
+                                .err = DeleteError.IsNotDirectory,
+                            },
+                            .ROFS => .{
+                                .err = DeleteError.ReadOnlyFileSystem,
+                            },
+                            .BADF => .{
+                                .err = DeleteError.InvalidFd,
+                            },
                             // rmdir
-                            .INVAL => .{ .err = DeleteError.InvalidArguments },
-                            .NOTEMPTY => .{ .err = DeleteError.NotEmpty },
-                            else => .{ .err = DeleteError.Unexpected },
+                            .INVAL => .{
+                                .err = DeleteError.InvalidArguments,
+                            },
+                            .NOTEMPTY => .{
+                                .err = DeleteError.NotEmpty,
+                            },
+                            else => .{
+                                .err = DeleteError.Unexpected,
+                            },
                         };
                     };
 
@@ -966,37 +1143,77 @@ fn reap(
                     const result: results.ReadResult = result: {
                         const e: linux.E = @fromBackingInt(@intCast(-cqe.res));
                         break :result switch (e) {
-                            .AGAIN => .{ .err = ReadError.WouldBlock },
-                            .BADF => .{ .err = ReadError.InvalidFd },
-                            .FAULT => .{ .err = ReadError.InvalidAddress },
-                            .INVAL => .{ .err = ReadError.InvalidArguments },
-                            .IO => .{ .err = ReadError.IoError },
-                            .ISDIR => .{ .err = ReadError.IsDirectory },
-                            else => .{ .err = ReadError.Unexpected },
+                            .AGAIN => .{
+                                .err = ReadError.WouldBlock,
+                            },
+                            .BADF => .{
+                                .err = ReadError.InvalidFd,
+                            },
+                            .FAULT => .{
+                                .err = ReadError.InvalidAddress,
+                            },
+                            .INVAL => .{
+                                .err = ReadError.InvalidArguments,
+                            },
+                            .IO => .{
+                                .err = ReadError.IoError,
+                            },
+                            .ISDIR => .{
+                                .err = ReadError.IsDirectory,
+                            },
+                            else => .{
+                                .err = ReadError.Unexpected,
+                            },
                         };
                     };
 
                     break :blk .{ .read = result };
                 },
                 .write => {
-                    if (cqe.res > 0) break :blk .{ .write = .{ .actual = @intCast(cqe.res) } };
+                    if (cqe.res > 0) break :blk .{
+                        .write = .{
+                            .actual = @intCast(cqe.res),
+                        },
+                    };
 
                     const WriteError = results.WriteError;
                     const result: results.WriteResult = result: {
                         const e: linux.E = @fromBackingInt(@intCast(-cqe.res));
                         break :result switch (e) {
                             .INVAL => unreachable,
-                            .AGAIN => .{ .err = WriteError.WouldBlock },
-                            .BADF => .{ .err = WriteError.InvalidFd },
-                            .DESTADDRREQ => .{ .err = WriteError.NoDestinationAddress },
-                            .DQUOT => .{ .err = WriteError.DiskQuotaExceeded },
-                            .FAULT => .{ .err = WriteError.InvalidAddress },
-                            .FBIG => .{ .err = WriteError.FileTooBig },
-                            .IO => .{ .err = WriteError.IoError },
-                            .NOSPC => .{ .err = WriteError.NoSpace },
-                            .PERM => .{ .err = WriteError.AccessDenied },
-                            .PIPE => .{ .err = WriteError.BrokenPipe },
-                            else => .{ .err = WriteError.Unexpected },
+                            .AGAIN => .{
+                                .err = WriteError.WouldBlock,
+                            },
+                            .BADF => .{
+                                .err = WriteError.InvalidFd,
+                            },
+                            .DESTADDRREQ => .{
+                                .err = WriteError.NoDestinationAddress,
+                            },
+                            .DQUOT => .{
+                                .err = WriteError.DiskQuotaExceeded,
+                            },
+                            .FAULT => .{
+                                .err = WriteError.InvalidAddress,
+                            },
+                            .FBIG => .{
+                                .err = WriteError.FileTooBig,
+                            },
+                            .IO => .{
+                                .err = WriteError.IoError,
+                            },
+                            .NOSPC => .{
+                                .err = WriteError.NoSpace,
+                            },
+                            .PERM => .{
+                                .err = WriteError.AccessDenied,
+                            },
+                            .PIPE => .{
+                                .err = WriteError.BrokenPipe,
+                            },
+                            else => .{
+                                .err = WriteError.Unexpected,
+                            },
                         };
                     };
 
@@ -1020,23 +1237,45 @@ fn reap(
                                 .nanoseconds = (statx.ctime.sec * std.time.ns_per_s) + statx.ctime.nsec,
                             },
                         };
-                        break :blk .{ .stat = .{ .actual = stat } };
+                        break :blk .{ .stat = .{
+                            .actual = stat,
+                        } };
                     }
 
                     const StatError = results.StatError;
                     const result: results.StatResult = result: {
                         const e: linux.E = @fromBackingInt(@intCast(-cqe.res));
                         break :result switch (e) {
-                            .ACCES => .{ .err = StatError.AccessDenied },
-                            .BADF => .{ .err = StatError.InvalidFd },
-                            .FAULT => .{ .err = StatError.InvalidAddress },
-                            .INVAL => .{ .err = StatError.InvalidArguments },
-                            .LOOP => .{ .err = StatError.Loop },
-                            .NAMETOOLONG => .{ .err = StatError.NameTooLong },
-                            .NOENT => .{ .err = StatError.NotFound },
-                            .NOMEM => .{ .err = StatError.OutOfMemory },
-                            .NOTDIR => .{ .err = StatError.NotADirectory },
-                            else => .{ .err = StatError.Unexpected },
+                            .ACCES => .{
+                                .err = StatError.AccessDenied,
+                            },
+                            .BADF => .{
+                                .err = StatError.InvalidFd,
+                            },
+                            .FAULT => .{
+                                .err = StatError.InvalidAddress,
+                            },
+                            .INVAL => .{
+                                .err = StatError.InvalidArguments,
+                            },
+                            .LOOP => .{
+                                .err = StatError.Loop,
+                            },
+                            .NAMETOOLONG => .{
+                                .err = StatError.NameTooLong,
+                            },
+                            .NOENT => .{
+                                .err = StatError.NotFound,
+                            },
+                            .NOMEM => .{
+                                .err = StatError.OutOfMemory,
+                            },
+                            .NOTDIR => .{
+                                .err = StatError.NotADirectory,
+                            },
+                            else => .{
+                                .err = StatError.Unexpected,
+                            },
                         };
                     };
 

--- a/src/aio/IoUring.zig
+++ b/src/aio/IoUring.zig
@@ -211,7 +211,6 @@ fn queue_job(
             inner.kind,
         ),
         .recv => |inner| uring.queue_recv(
-            uring,
             allocator,
             task,
             inner.socket,

--- a/src/aio/IoUring.zig
+++ b/src/aio/IoUring.zig
@@ -1,6 +1,6 @@
 pub const IoUring = @This();
 
-inner: *linux.IoUring,
+uring: *linux.IoUring,
 wake_event_fd: posix.fd_t,
 wake_event_buffer: []u8,
 
@@ -59,7 +59,7 @@ pub fn init(
             const parent_uring: *IoUring = @ptrCast(
                 @alignCast(parent.runner),
             );
-            debug.assert(parent_uring.inner.fd >= 0);
+            debug.assert(parent_uring.uring.fd >= 0);
 
             // Initialize using the WQ from the parent ring.
             const flags: u32 = base_flags | linux.IORING_SETUP_ATTACH_WQ;
@@ -67,7 +67,7 @@ pub fn init(
                 linux.io_uring_params,
                 .{
                     .flags = flags,
-                    .wq_fd = @as(u32, @intCast(parent_uring.inner.fd)),
+                    .wq_fd = @as(u32, @intCast(parent_uring.uring.fd)),
                 },
             );
 
@@ -120,7 +120,7 @@ pub fn init(
     errdefer allocator.free(cqes);
 
     return .{
-        .inner = uring,
+        .uring = uring,
         .wake_event_fd = wake_event_fd,
         .wake_event_buffer = wake_event_buffer,
         .jobs = jobs,
@@ -130,11 +130,11 @@ pub fn init(
 
 pub fn inner_deinit(io_uring: *IoUring, allocator: mem.Allocator) void {
     syscall.close(io_uring.wake_event_fd);
-    io_uring.inner.deinit();
+    io_uring.uring.deinit();
     io_uring.jobs.deinit(allocator);
     allocator.free(io_uring.wake_event_buffer);
     allocator.free(io_uring.cqes);
-    allocator.destroy(io_uring.inner);
+    allocator.destroy(io_uring.uring);
 }
 
 fn deinit(runner: *anyopaque, allocator: mem.Allocator) void {
@@ -150,77 +150,77 @@ fn queue_job(
 ) Errors.QueueJob!void {
     const uring: *IoUring = @ptrCast(@alignCast(runner));
     (switch (job) {
-        .timer => |inner| uring.queue_timer(
+        .timer => |timer| uring.queue_timer(
             allocator,
             task,
-            inner,
+            timer,
         ),
-        .open => |inner| uring.queue_open(
+        .open => |open| uring.queue_open(
             allocator,
             task,
-            inner.path,
-            inner.flags,
+            open.path,
+            open.flags,
         ),
-        .delete => |inner| uring.queue_delete(
+        .delete => |delete| uring.queue_delete(
             allocator,
             task,
-            inner.path,
-            inner.is_dir,
+            delete.path,
+            delete.is_dir,
         ),
-        .mkdir => |inner| uring.queue_mkdir(
+        .mkdir => |mkdir| uring.queue_mkdir(
             allocator,
             task,
-            inner.path,
-            inner.mode,
+            mkdir.path,
+            mkdir.mode,
         ),
-        .stat => |inner| uring.queue_stat(
+        .stat => |stat| uring.queue_stat(
             allocator,
             task,
-            inner,
+            stat,
         ),
-        .read => |inner| uring.queue_read(
+        .read => |read| uring.queue_read(
             allocator,
             task,
-            inner.fd,
-            inner.buffer,
-            inner.offset,
+            read.fd,
+            read.buffer,
+            read.offset,
         ),
-        .write => |inner| uring.queue_write(
+        .write => |write| uring.queue_write(
             allocator,
             task,
-            inner.fd,
-            inner.buffer,
-            inner.offset,
+            write.fd,
+            write.buffer,
+            write.offset,
         ),
-        .close => |inner| uring.queue_close(
+        .close => |close| uring.queue_close(
             allocator,
             task,
-            inner,
+            close,
         ),
-        .accept => |inner| uring.queue_accept(
+        .accept => |accept| uring.queue_accept(
             allocator,
             task,
-            inner.socket,
-            inner.kind,
+            accept.socket,
+            accept.kind,
         ),
-        .connect => |inner| uring.queue_connect(
+        .connect => |connect| uring.queue_connect(
             allocator,
             task,
-            inner.socket,
-            inner.addr,
-            inner.kind,
+            connect.socket,
+            connect.addr,
+            connect.kind,
         ),
-        .recv => |inner| uring.queue_recv(
+        .recv => |recv| uring.queue_recv(
             allocator,
             task,
-            inner.socket,
-            inner.buffer,
+            recv.socket,
+            recv.buffer,
         ),
-        .send => |inner| uring.queue_send(
+        .send => |send| uring.queue_send(
             allocator,
             task,
-            inner.socket,
-            inner.buffer,
+            send.socket,
+            send.buffer,
         ),
     }) catch |e| switch (e) {
         error.SubmissionQueueFull => {
@@ -257,7 +257,7 @@ fn queue_timer(
     };
     item.timespec = timespec_ptr;
 
-    _ = try io_uring.inner.timeout(
+    _ = try io_uring.uring.timeout(
         index,
         timespec_ptr,
         0,
@@ -312,17 +312,17 @@ fn queue_open(
     const perms = flags.perms orelse 0;
 
     switch (path) {
-        .rel => |inner| _ = try io_uring.inner.openat(
+        .rel => |rel| _ = try io_uring.uring.openat(
             index,
-            inner.dir,
-            inner.path.ptr,
+            rel.dir,
+            rel.path.ptr,
             o_flags,
             @intCast(perms),
         ),
-        .abs => |inner| _ = try io_uring.inner.openat(
+        .abs => |abs| _ = try io_uring.uring.openat(
             index,
             posix.AT.FDCWD,
-            inner.ptr,
+            abs.ptr,
             o_flags,
             @intCast(perms),
         ),
@@ -354,13 +354,13 @@ fn queue_delete(
     const mode: u32 = if (is_dir) posix.AT.REMOVEDIR else 0;
 
     switch (path) {
-        .rel => |rel| _ = try io_uring.inner.unlinkat(
+        .rel => |rel| _ = try io_uring.uring.unlinkat(
             index,
             rel.dir,
             rel.path.ptr,
             mode,
         ),
-        .abs => |abs| _ = try io_uring.inner.unlinkat(
+        .abs => |abs| _ = try io_uring.uring.unlinkat(
             index,
             posix.AT.FDCWD,
             abs.ptr,
@@ -392,13 +392,13 @@ fn queue_mkdir(
     };
 
     switch (path) {
-        .rel => |rel| _ = try io_uring.inner.mkdirat(
+        .rel => |rel| _ = try io_uring.uring.mkdirat(
             index,
             rel.dir,
             rel.path.ptr,
             @intCast(mode),
         ),
-        .abs => |abs| _ = try io_uring.inner.mkdirat(
+        .abs => |abs| _ = try io_uring.uring.mkdirat(
             index,
             posix.AT.FDCWD,
             abs.ptr,
@@ -427,7 +427,7 @@ fn queue_stat(
     errdefer allocator.destroy(statx_ptr);
     item.statx = statx_ptr;
 
-    _ = try io_uring.inner.statx(
+    _ = try io_uring.uring.statx(
         index,
         fd,
         "",
@@ -464,7 +464,7 @@ fn queue_read(
         .task = task,
     };
 
-    _ = try io_uring.inner.read(
+    _ = try io_uring.uring.read(
         index,
         fd,
         .{ .buffer = buffer },
@@ -502,7 +502,7 @@ fn queue_write(
         .task = task,
     };
 
-    _ = try io_uring.inner.write(
+    _ = try io_uring.uring.write(
         index,
         fd,
         buffer,
@@ -529,7 +529,7 @@ fn queue_close(
         .task = task,
     };
 
-    _ = try io_uring.inner.close(index, fd);
+    _ = try io_uring.uring.close(index, fd);
 }
 
 fn queue_accept(
@@ -559,7 +559,7 @@ fn queue_accept(
     };
     var sockaddr, var socklen = item.job.type.accept.addr.toPosix();
 
-    _ = try io_uring.inner.accept(
+    _ = try io_uring.uring.accept(
         index,
         socket,
         &sockaddr,
@@ -596,7 +596,7 @@ fn queue_connect(
     };
     const sockaddr, const socklen = item.job.type.connect.addr.toPosix();
 
-    _ = try io_uring.inner.connect(
+    _ = try io_uring.uring.connect(
         index,
         socket,
         &sockaddr,
@@ -629,7 +629,7 @@ fn queue_recv(
         .task = task,
     };
 
-    _ = try io_uring.inner.recv(
+    _ = try io_uring.uring.recv(
         index,
         socket,
         .{ .buffer = buffer },
@@ -659,7 +659,7 @@ fn queue_send(
         .task = task,
     };
 
-    _ = try io_uring.inner.send(index, socket, buffer, 0);
+    _ = try io_uring.uring.send(index, socket, buffer, 0);
 }
 
 inline fn queue_wake(io_uring: *IoUring, alloator: mem.Allocator) Error!void {
@@ -675,7 +675,7 @@ inline fn queue_wake(io_uring: *IoUring, alloator: mem.Allocator) Error!void {
         .task = undefined,
     };
 
-    _ = try io_uring.inner.read(
+    _ = try io_uring.uring.read(
         index,
         io_uring.wake_event_fd,
         .{ .buffer = io_uring.wake_event_buffer },
@@ -694,7 +694,7 @@ fn submit(runner: *anyopaque) Errors.Submit!void {
     const uring: *IoUring = @ptrCast(@alignCast(runner));
 
     _ = while (true) {
-        break uring.inner.submit() catch |e| switch (e) {
+        break uring.uring.submit() catch |e| switch (e) {
             error.SignalInterrupt => continue,
             else => |err| return err,
         };
@@ -712,7 +712,7 @@ fn reap(
     const uring_nr: u32 = if (wait) 1 else 0;
 
     const count = while (true) {
-        break uring.inner.copy_cqes(uring.cqes[0..], uring_nr) catch |e|
+        break uring.uring.copy_cqes(uring.cqes[0..], uring_nr) catch |e|
             {
                 switch (e) {
                     error.SignalInterrupt => continue,
@@ -743,14 +743,14 @@ fn reap(
                     break :blk .none;
                 },
                 .close => break :blk .close,
-                .accept => |inner| {
-                    if (cqe.res >= 0) switch (inner.kind) {
+                .accept => |accept| {
+                    if (cqe.res >= 0) switch (accept.kind) {
                         .tcp, .unix => break :blk .{
                             .accept = .{
                                 .actual = .{
                                     .handle = cqe.res,
-                                    .addr = inner.addr,
-                                    .kind = inner.kind,
+                                    .addr = accept.addr,
+                                    .kind = accept.kind,
                                 },
                             },
                         },
@@ -971,8 +971,8 @@ fn reap(
 
                     break :blk .{ .mkdir = result };
                 },
-                .open => |inner| {
-                    if (cqe.res >= 0) switch (inner.kind) {
+                .open => |open| {
+                    if (cqe.res >= 0) switch (open.kind) {
                         .file => break :blk .{
                             .open = .{
                                 .actual = .{ .file = .{
@@ -990,7 +990,7 @@ fn reap(
                     };
 
                     const OpenError = results.OpenError;
-                    const result: results.InnerOpenResult = result: {
+                    const result: results.OpenResult = result: {
                         const e: linux.E = @fromBackingInt(@intCast(-cqe.res));
                         break :result switch (e) {
                             .ACCES, .PERM => .{

--- a/src/aio/Kqueue.zig
+++ b/src/aio/Kqueue.zig
@@ -60,11 +60,11 @@ pub fn init(allocator: std.mem.Allocator, options: AsyncIO.Options) !Kqueue {
     };
 }
 
-pub fn inner_deinit(self: *Kqueue, allocator: std.mem.Allocator) void {
-    syscall.close(self.kqueue_fd);
-    allocator.free(self.events);
-    allocator.free(self.changes);
-    self.jobs.deinit();
+pub fn inner_deinit(kqueue: *Kqueue, allocator: std.mem.Allocator) void {
+    syscall.close(kqueue.kqueue_fd);
+    allocator.free(kqueue.events);
+    allocator.free(kqueue.changes);
+    kqueue.jobs.deinit(allocator);
 }
 
 pub fn deinit(runner: *anyopaque, allocator: std.mem.Allocator) void {
@@ -72,26 +72,62 @@ pub fn deinit(runner: *anyopaque, allocator: std.mem.Allocator) void {
     kqueue.inner_deinit(allocator);
 }
 
-pub fn queue_job(runner: *anyopaque, task: usize, job: AsyncIO.Submission) Errors.QueueJob!void {
+pub fn queue_job(
+    runner: *anyopaque,
+    allocator: mem.Allocator,
+    task: usize,
+    job: AsyncIO.Submission,
+) Errors.QueueJob!void {
     const kqueue: *Kqueue = @ptrCast(@alignCast(runner));
 
     (switch (job) {
-        .timer => |inner| queue_timer(kqueue, task, inner),
-        .accept => |inner| queue_accept(kqueue, task, inner.socket, inner.kind),
-        .connect => |inner| queue_connect(kqueue, task, inner.socket, inner.addr, inner.kind),
-        .recv => |inner| queue_recv(kqueue, task, inner.socket, inner.buffer),
-        .send => |inner| queue_send(kqueue, task, inner.socket, inner.buffer),
+        .timer => |inner| kqueue.queue_timer(
+            allocator,
+            task,
+            inner,
+        ),
+        .accept => |inner| kqueue.queue_accept(
+            allocator,
+            task,
+            inner.socket,
+            inner.kind,
+        ),
+        .connect => |inner| kqueue.queue_connect(
+            allocator,
+            task,
+            inner.socket,
+            inner.addr,
+            inner.kind,
+        ),
+        .recv => |inner| kqueue.queue_recv(
+            allocator,
+            task,
+            inner.socket,
+            inner.buffer,
+        ),
+        .send => |inner| kqueue.queue_send(
+            allocator,
+            task,
+            inner.socket,
+            inner.buffer,
+        ),
         .open, .delete, .mkdir, .stat, .read, .write, .close => unreachable,
     }) catch |e| if (e == error.ChangeQueueFull) {
         try submit(runner);
-        try queue_job(runner, task, job);
+        try queue_job(runner, allocator, task, job);
     } else return e;
 }
 
-fn queue_timer(self: *Kqueue, task: usize, duration: Io.Duration) Error!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
-    const item = self.jobs.get_ptr(index);
+fn queue_timer(
+    kqueue: *Kqueue,
+    allocator: mem.Allocator,
+    task: usize,
+    duration: Io.Duration,
+) Error!void {
+    const index = try kqueue.jobs.borrow_hint(allocator, task);
+    errdefer kqueue.jobs.release(index);
+
+    const item = kqueue.jobs.get_ptr(index);
 
     item.* = .{
         .index = index,
@@ -102,9 +138,9 @@ fn queue_timer(self: *Kqueue, task: usize, duration: Io.Duration) Error!void {
     // kqueue uses milliseconds.
     const milliseconds = duration.toMilliseconds();
 
-    if (self.change_count < self.changes.len) {
-        const event = &self.changes[self.change_count];
-        self.change_count += 1;
+    if (kqueue.change_count < kqueue.changes.len) {
+        const event = &kqueue.changes[kqueue.change_count];
+        kqueue.change_count += 1;
 
         event.* = .{
             .ident = index,
@@ -118,14 +154,16 @@ fn queue_timer(self: *Kqueue, task: usize, duration: Io.Duration) Error!void {
 }
 
 fn queue_accept(
-    self: *Kqueue,
+    kqueue: *Kqueue,
+    allocator: mem.Allocator,
     task: usize,
     socket: net.Socket.Handle,
     kind: net.Socket.Kind,
 ) Error!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
-    const item = self.jobs.get_ptr(index);
+    const index = try kqueue.jobs.borrow_hint(allocator, task);
+    errdefer kqueue.jobs.release(index);
+
+    const item = kqueue.jobs.get_ptr(index);
     item.* = .{
         .index = index,
         .type = .{
@@ -138,9 +176,9 @@ fn queue_accept(
         .task = task,
     };
 
-    if (self.change_count < self.changes.len) {
-        const event = &self.changes[self.change_count];
-        self.change_count += 1;
+    if (kqueue.change_count < kqueue.changes.len) {
+        const event = &kqueue.changes[kqueue.change_count];
+        kqueue.change_count += 1;
 
         event.* = .{
             .ident = @intCast(socket),
@@ -154,16 +192,18 @@ fn queue_accept(
 }
 
 fn queue_connect(
-    self: *Kqueue,
+    kqueue: *Kqueue,
+    allocator: mem.Allocator,
     task: usize,
     socket: net.Socket.Handle,
     // TODO: take *const
     addr: net.Socket.Address,
     kind: net.Socket.Kind,
 ) Errors.Connect!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
-    const item = self.jobs.get_ptr(index);
+    const index = try kqueue.jobs.borrow_hint(allocator, task);
+    errdefer kqueue.jobs.release(index);
+
+    const item = kqueue.jobs.get_ptr(index);
     item.* = .{
         .index = index,
         .type = .{
@@ -176,7 +216,7 @@ fn queue_connect(
         .task = task,
     };
 
-    if (self.change_count < self.changes.len) {
+    if (kqueue.change_count < kqueue.changes.len) {
         syscall.connect(
             socket,
             &addr,
@@ -185,8 +225,8 @@ fn queue_connect(
             else => |err| return err,
         };
 
-        const event = &self.changes[self.change_count];
-        self.change_count += 1;
+        const event = &kqueue.changes[kqueue.change_count];
+        kqueue.change_count += 1;
 
         event.* = .{
             .ident = @intCast(socket),
@@ -200,14 +240,16 @@ fn queue_connect(
 }
 
 fn queue_recv(
-    self: *Kqueue,
+    kqueue: *Kqueue,
+    allocator: mem.Allocator,
     task: usize,
     socket: net.Socket.Handle,
     buffer: []u8,
 ) Error!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
-    const item = self.jobs.get_ptr(index);
+    const index = try kqueue.jobs.borrow_hint(allocator, task);
+    errdefer kqueue.jobs.release(index);
+
+    const item = kqueue.jobs.get_ptr(index);
     item.* = .{
         .index = index,
         .type = .{
@@ -219,9 +261,9 @@ fn queue_recv(
         .task = task,
     };
 
-    if (self.change_count < self.changes.len) {
-        const event = &self.changes[self.change_count];
-        self.change_count += 1;
+    if (kqueue.change_count < kqueue.changes.len) {
+        const event = &kqueue.changes[kqueue.change_count];
+        kqueue.change_count += 1;
 
         event.* = .{
             .ident = @intCast(socket),
@@ -235,14 +277,16 @@ fn queue_recv(
 }
 
 fn queue_send(
-    self: *Kqueue,
+    kqueue: *Kqueue,
+    allocator: mem.Allocator,
     task: usize,
     socket: net.Socket.Handle,
     buffer: []const u8,
 ) Error!void {
-    const index = try self.jobs.borrow_hint(task);
-    errdefer self.jobs.release(index);
-    const item = self.jobs.get_ptr(index);
+    const index = try kqueue.jobs.borrow_hint(allocator, task);
+    errdefer kqueue.jobs.release(index);
+
+    const item = kqueue.jobs.get_ptr(index);
     item.* = .{
         .index = index,
         .type = .{
@@ -254,9 +298,9 @@ fn queue_send(
         .task = task,
     };
 
-    if (self.change_count < self.changes.len) {
-        const event = &self.changes[self.change_count];
-        self.change_count += 1;
+    if (kqueue.change_count < kqueue.changes.len) {
+        const event = &kqueue.changes[kqueue.change_count];
+        kqueue.change_count += 1;
 
         event.* = .{
             .ident = @intCast(socket),
@@ -303,6 +347,7 @@ pub fn submit(runner: *anyopaque) Errors.Submit!void {
 
 pub fn reap(
     runner: *anyopaque,
+    _: mem.Allocator,
     completions: []results.Completion,
     wait: bool,
 ) ![]results.Completion {
@@ -474,9 +519,9 @@ pub fn reap(
     return completions[0..reaped];
 }
 
-pub fn to_async(self: *Kqueue) AsyncIO {
+pub fn to_async(kqueue: *Kqueue) AsyncIO {
     return .{
-        .runner = self,
+        .runner = kqueue,
         .features = .init(&.{
             .timer,
             .accept,
@@ -507,6 +552,7 @@ const Error = error{ChangeQueueFull} || pool.Error;
 const WAKE_IDENT = 1;
 
 const std = @import("std");
+const mem = std.mem;
 const debug = std.debug;
 const Io = std.Io;
 const posix = std.posix;

--- a/src/aio/Kqueue.zig
+++ b/src/aio/Kqueue.zig
@@ -80,35 +80,35 @@ pub fn queue_job(
     const kqueue: *Kqueue = @ptrCast(@alignCast(runner));
 
     (switch (job) {
-        .timer => |inner| kqueue.queue_timer(
+        .timer => |timer| kqueue.queue_timer(
             allocator,
             task,
-            inner,
+            timer,
         ),
-        .accept => |inner| kqueue.queue_accept(
+        .accept => |accept| kqueue.queue_accept(
             allocator,
             task,
-            inner.socket,
-            inner.kind,
+            accept.socket,
+            accept.kind,
         ),
-        .connect => |inner| kqueue.queue_connect(
+        .connect => |connect| kqueue.queue_connect(
             allocator,
             task,
-            inner.socket,
-            inner.addr,
-            inner.kind,
+            connect.socket,
+            connect.addr,
+            connect.kind,
         ),
-        .recv => |inner| kqueue.queue_recv(
+        .recv => |recv| kqueue.queue_recv(
             allocator,
             task,
-            inner.socket,
-            inner.buffer,
+            recv.socket,
+            recv.buffer,
         ),
-        .send => |inner| kqueue.queue_send(
+        .send => |send| kqueue.queue_send(
             allocator,
             task,
-            inner.socket,
-            inner.buffer,
+            send.socket,
+            send.buffer,
         ),
         .open, .delete, .mkdir, .stat, .read, .write, .close => unreachable,
     }) catch |e| if (e == error.ChangeQueueFull) {
@@ -386,17 +386,17 @@ pub fn reap(
                         job_complete = false;
                         break :result .wake;
                     },
-                    .timer => |inner| {
+                    .timer => |timer| {
                         debug.assert(event.filter == posix.system.EVFILT.TIMER);
-                        debug.assert(inner == .none);
+                        debug.assert(timer == .none);
                         break :result .none;
                     },
-                    .accept => |*inner| {
+                    .accept => |*accept| {
                         debug.assert(event.filter == posix.system.EVFILT.READ);
 
                         const socket_fd = syscall.accept(
-                            inner.socket,
-                            &inner.addr,
+                            accept.socket,
+                            &accept.addr,
                             0,
                         ) catch |err| break :result .{
                             .accept = .{
@@ -408,8 +408,8 @@ pub fn reap(
                             .accept = .{
                                 .actual = .{
                                     .handle = socket_fd,
-                                    .addr = inner.addr,
-                                    .kind = inner.kind,
+                                    .addr = accept.addr,
+                                    .kind = accept.kind,
                                 },
                             },
                         };
@@ -449,11 +449,11 @@ pub fn reap(
                             .connect = result,
                         };
                     },
-                    .recv => |inner| {
+                    .recv => |recv| {
                         debug.assert(event.filter == posix.system.EVFILT.READ);
                         const rc = syscall.recvfrom(
-                            inner.socket,
-                            inner.buffer,
+                            recv.socket,
+                            recv.buffer,
                             0,
                             null,
                             null,
@@ -476,11 +476,11 @@ pub fn reap(
                                 },
                             };
                     },
-                    .send => |inner| {
+                    .send => |send| {
                         debug.assert(event.filter == posix.system.EVFILT.WRITE);
                         const rc = syscall.send(
-                            inner.socket,
-                            inner.buffer,
+                            send.socket,
+                            send.buffer,
                             0,
                         ) catch |err| {
                             break :result .{

--- a/src/aio/Kqueue.zig
+++ b/src/aio/Kqueue.zig
@@ -1,7 +1,6 @@
 pub const Kqueue = @This();
 
 kqueue_fd: posix.fd_t,
-
 changes: []posix.Kevent,
 change_count: usize = 0,
 events: []posix.Kevent,

--- a/src/aio/Kqueue.zig
+++ b/src/aio/Kqueue.zig
@@ -7,7 +7,7 @@ events: []posix.Kevent,
 
 jobs: pool.Pool(Job),
 
-pub fn init(allocator: std.mem.Allocator, options: AsyncIO.Options) !Kqueue {
+pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) !Kqueue {
     const kqueue_fd = try syscall.kqueue();
     debug.assert(kqueue_fd > -1);
     errdefer syscall.close(kqueue_fd);
@@ -59,14 +59,14 @@ pub fn init(allocator: std.mem.Allocator, options: AsyncIO.Options) !Kqueue {
     };
 }
 
-pub fn inner_deinit(kqueue: *Kqueue, allocator: std.mem.Allocator) void {
+pub fn inner_deinit(kqueue: *Kqueue, allocator: mem.Allocator) void {
     syscall.close(kqueue.kqueue_fd);
     allocator.free(kqueue.events);
     allocator.free(kqueue.changes);
     kqueue.jobs.deinit(allocator);
 }
 
-pub fn deinit(runner: *anyopaque, allocator: std.mem.Allocator) void {
+pub fn deinit(runner: *anyopaque, allocator: mem.Allocator) void {
     const kqueue: *Kqueue = @ptrCast(@alignCast(runner));
     kqueue.inner_deinit(allocator);
 }

--- a/src/aio/Poll.zig
+++ b/src/aio/Poll.zig
@@ -129,36 +129,31 @@ pub fn queue_job(
     const poll: *Poll = @ptrCast(@alignCast(runner));
 
     try switch (job) {
-        .timer => |inner| queue_timer(
-            poll,
+        .timer => |inner| poll.queue_timer(
             allocator,
             task,
             inner,
         ),
-        .accept => |inner| queue_accept(
-            poll,
+        .accept => |inner| poll.queue_accept(
             allocator,
             task,
             inner.socket,
             inner.kind,
         ),
-        .connect => |inner| queue_connect(
-            poll,
+        .connect => |inner| poll.queue_connect(
             allocator,
             task,
             inner.socket,
             inner.addr,
             inner.kind,
         ),
-        .recv => |inner| queue_recv(
-            poll,
+        .recv => |inner| poll.queue_recv(
             allocator,
             task,
             inner.socket,
             inner.buffer,
         ),
-        .send => |inner| queue_send(
-            poll,
+        .send => |inner| poll.queue_send(
             allocator,
             task,
             inner.socket,
@@ -364,15 +359,20 @@ pub fn reap(
             const result: results.Result = result: {
                 switch (job.type) {
                     .wake => {
-                        debug.assert(pfd.revents & syscall.POLL.IN != 0 or pfd.revents & syscall.POLL.RDNORM != 0);
+                        debug.assert(pfd.revents & syscall.POLL.IN != 0 or
+                            pfd.revents & syscall.POLL.RDNORM != 0);
 
                         var buf: [8]u8 = undefined;
-                        _ = syscall.read(poll.wake_pipe[0], &buf) catch unreachable;
+                        _ = syscall.read(
+                            poll.wake_pipe[0],
+                            &buf,
+                        ) catch unreachable;
                         remove = false;
                         break :result .wake;
                     },
                     .accept => |*inner| {
-                        debug.assert(pfd.revents & syscall.POLL.IN != 0 or pfd.revents & syscall.POLL.RDNORM != 0);
+                        debug.assert(pfd.revents & syscall.POLL.IN != 0 or
+                            pfd.revents & syscall.POLL.RDNORM != 0);
 
                         const AcceptError = results.AcceptError;
                         const socket = syscall.accept(
@@ -382,7 +382,10 @@ pub fn reap(
                         ) catch |e| {
                             const err = switch (e) {
                                 error.WouldBlock => {
-                                    log.debug("accept wouldblock - not removing", .{});
+                                    log.debug(
+                                        "accept wouldblock - not removing",
+                                        .{},
+                                    );
                                     remove = false;
                                     continue;
                                 },
@@ -394,7 +397,9 @@ pub fn reap(
                                 else => AcceptError.Unexpected,
                             };
 
-                            break :result .{ .accept = .{ .err = err } };
+                            break :result .{ .accept = .{
+                                .err = err,
+                            } };
                         };
 
                         break :result .{
@@ -415,7 +420,9 @@ pub fn reap(
                                 .err = results.ConnectError.Unexpected,
                             } };
                         } else {
-                            break :result .{ .connect = .actual };
+                            break :result .{
+                                .connect = .actual,
+                            };
                         }
                     },
                     .recv => |inner| {
@@ -436,7 +443,10 @@ pub fn reap(
                         ) catch |e| {
                             const err = switch (e) {
                                 error.WouldBlock => {
-                                    log.debug("recv wouldblock - not removing", .{});
+                                    log.debug(
+                                        "recv wouldblock - not removing",
+                                        .{},
+                                    );
                                     remove = false;
                                     continue;
                                 },
@@ -444,11 +454,19 @@ pub fn reap(
                                 else => RecvError.Unexpected,
                             };
 
-                            break :result .{ .recv = .{ .err = err } };
+                            break :result .{ .recv = .{
+                                .err = err,
+                            } };
                         };
 
-                        if (count == 0) break :result .{ .recv = .{ .err = RecvError.Closed } };
-                        break :result .{ .recv = .{ .actual = count } };
+                        if (count == 0) break :result .{
+                            .recv = .{
+                                .err = RecvError.Closed,
+                            },
+                        };
+                        break :result .{ .recv = .{
+                            .actual = count,
+                        } };
                     },
                     .send => |inner| {
                         const SendError = results.SendError;
@@ -467,7 +485,10 @@ pub fn reap(
                             log.err("send failed with {}", .{e});
                             const err = switch (e) {
                                 error.WouldBlock => {
-                                    log.debug("send wouldblock - not removing", .{});
+                                    log.debug(
+                                        "send wouldblock - not removing",
+                                        .{},
+                                    );
                                     remove = false;
                                     continue;
                                 },
@@ -545,11 +566,15 @@ const TimerPair = struct {
     task: usize,
 };
 
-const TimerQueue = std.PriorityQueue(TimerPair, void, struct {
-    fn compare(_: void, a: TimerPair, b: TimerPair) math.Order {
-        return math.order(a.duration.nanoseconds, b.duration.nanoseconds);
-    }
-}.compare);
+const TimerQueue = std.PriorityQueue(
+    TimerPair,
+    void,
+    struct {
+        fn compare(_: void, a: TimerPair, b: TimerPair) math.Order {
+            return math.order(a.duration.nanoseconds, b.duration.nanoseconds);
+        }
+    }.compare,
+);
 
 const std = @import("std");
 const Io = std.Io;

--- a/src/aio/Poll.zig
+++ b/src/aio/Poll.zig
@@ -1,10 +1,10 @@
 pub const Poll = @This();
 
-allocator: mem.Allocator,
 wake_pipe: [2]fs.File.Handle,
-
 fd_list: std.ArrayList(syscall.pollfd),
-fd_job_map: std.AutoHashMap(fs.File.Handle, Job),
+// TODO: audit all uses of `AutoHashMap` if they can be replaced
+// by array variant
+fd_job_map: std.AutoHashMapUnmanaged(fs.File.Handle, Job),
 
 timers: TimerQueue,
 
@@ -38,7 +38,11 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) !Poll {
             // Required to prevent INVALID_ADDRESS_COMPONENT error on AFD
             var binded_addr = mem.zeroes(std.posix.sockaddr);
             var binded_size: std.posix.socklen_t = @sizeOf(std.posix.sockaddr);
-            try syscall.getsockname(server_socket, &binded_addr, &binded_size);
+            try syscall.getsockname(
+                server_socket,
+                &binded_addr,
+                &binded_size,
+            );
             const bounded_addr = net.Socket.Address.fromAny(&binded_addr);
 
             try syscall.connect(write_end, &bounded_addr);
@@ -61,9 +65,10 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) !Poll {
     );
     errdefer fd_list.deinit(allocator);
 
-    var fd_job_map: std.AutoHashMap(fs.File.Handle, Job) = .init(allocator);
-    errdefer fd_job_map.deinit();
-    try fd_job_map.ensureTotalCapacity(@intCast(size));
+    var fd_job_map: std.AutoHashMapUnmanaged(fs.File.Handle, Job) = .empty;
+    errdefer fd_job_map.deinit(allocator);
+
+    try fd_job_map.ensureTotalCapacity(allocator, @intCast(size));
 
     if (comptime native_os == .windows) {
         try fd_list.append(allocator, .{
@@ -71,7 +76,7 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) !Poll {
             .events = syscall.POLL.IN,
             .revents = 0,
         });
-        try fd_job_map.put(@ptrCast(pipe[0]), .{
+        try fd_job_map.put(allocator, @ptrCast(pipe[0]), .{
             .index = 0,
             .type = .wake,
             .task = 0,
@@ -82,7 +87,7 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) !Poll {
             .events = syscall.POLL.IN,
             .revents = 0,
         });
-        try fd_job_map.put(pipe[0], .{
+        try fd_job_map.put(allocator, pipe[0], .{
             .index = 0,
             .type = .wake,
             .task = 0,
@@ -93,7 +98,6 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) !Poll {
     errdefer timers.deinit(allocator);
 
     return .{
-        .allocator = allocator,
         .wake_pipe = pipe,
         .fd_list = fd_list,
         .fd_job_map = fd_job_map,
@@ -101,11 +105,14 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) !Poll {
     };
 }
 
-pub fn inner_deinit(self: *Poll, allocator: mem.Allocator) void {
-    self.fd_list.deinit(allocator);
-    self.fd_job_map.deinit();
-    self.timers.deinit(allocator);
-    for (self.wake_pipe) |fd| if (comptime native_os == .windows) (syscall.ws2.closesock(fd) catch unreachable) else syscall.close(fd);
+pub fn inner_deinit(poll: *Poll, allocator: mem.Allocator) void {
+    poll.fd_list.deinit(allocator);
+    poll.fd_job_map.deinit(allocator);
+    poll.timers.deinit(allocator);
+    for (poll.wake_pipe) |fd| if (comptime native_os == .windows)
+        syscall.ws2.closesock(fd) catch unreachable
+    else
+        syscall.close(fd);
 }
 
 fn deinit(runner: *anyopaque, allocator: mem.Allocator) void {
@@ -113,39 +120,80 @@ fn deinit(runner: *anyopaque, allocator: mem.Allocator) void {
     poll.inner_deinit(allocator);
 }
 
-pub fn queue_job(runner: *anyopaque, task: usize, job: AsyncIO.Submission) Errors.QueueJob!void {
+pub fn queue_job(
+    runner: *anyopaque,
+    allocator: mem.Allocator,
+    task: usize,
+    job: AsyncIO.Submission,
+) Errors.QueueJob!void {
     const poll: *Poll = @ptrCast(@alignCast(runner));
 
     try switch (job) {
-        .timer => |inner| queue_timer(poll, task, inner),
-        .accept => |inner| queue_accept(poll, task, inner.socket, inner.kind),
-        .connect => |inner| queue_connect(poll, task, inner.socket, inner.addr, inner.kind),
-        .recv => |inner| queue_recv(poll, task, inner.socket, inner.buffer),
-        .send => |inner| queue_send(poll, task, inner.socket, inner.buffer),
+        .timer => |inner| queue_timer(
+            poll,
+            allocator,
+            task,
+            inner,
+        ),
+        .accept => |inner| queue_accept(
+            poll,
+            allocator,
+            task,
+            inner.socket,
+            inner.kind,
+        ),
+        .connect => |inner| queue_connect(
+            poll,
+            allocator,
+            task,
+            inner.socket,
+            inner.addr,
+            inner.kind,
+        ),
+        .recv => |inner| queue_recv(
+            poll,
+            allocator,
+            task,
+            inner.socket,
+            inner.buffer,
+        ),
+        .send => |inner| queue_send(
+            poll,
+            allocator,
+            task,
+            inner.socket,
+            inner.buffer,
+        ),
         .open, .delete, .mkdir, .stat, .read, .write, .close => unreachable,
     };
 }
 
-fn queue_timer(self: *Poll, task: usize, duration: Io.Duration) Errors.Timer!void {
+fn queue_timer(
+    poll: *Poll,
+    allocator: mem.Allocator,
+    task: usize,
+    duration: Io.Duration,
+) Errors.Timer!void {
     const current = syscall.now(.real);
-    try self.timers.push(self.allocator, .{
+    try poll.timers.push(allocator, .{
         .duration = current.addDuration(duration),
         .task = task,
     });
 }
 
 fn queue_accept(
-    self: *Poll,
+    poll: *Poll,
+    allocator: mem.Allocator,
     task: usize,
     socket: net.Socket.Handle,
     kind: net.Socket.Kind,
 ) Errors.Accept!void {
-    try self.fd_list.append(self.allocator, .{
+    try poll.fd_list.append(allocator, .{
         .fd = socket,
         .events = syscall.POLL.IN,
         .revents = 0,
     });
-    try self.fd_job_map.put(socket, .{
+    try poll.fd_job_map.put(allocator, socket, .{
         .index = 0,
         .type = .{
             .accept = .{
@@ -159,7 +207,8 @@ fn queue_accept(
 }
 
 fn queue_connect(
-    self: *Poll,
+    poll: *Poll,
+    allocator: mem.Allocator,
     task: usize,
     socket: net.Socket.Handle,
     // TODO: take by *const
@@ -174,12 +223,12 @@ fn queue_connect(
         else => |err| return err,
     };
 
-    try self.fd_list.append(self.allocator, .{
+    try poll.fd_list.append(allocator, .{
         .fd = socket,
         .events = syscall.POLL.OUT,
         .revents = 0,
     });
-    try self.fd_job_map.put(socket, .{
+    try poll.fd_job_map.put(allocator, socket, .{
         .index = 0,
         .type = .{
             .connect = .{
@@ -193,17 +242,18 @@ fn queue_connect(
 }
 
 fn queue_recv(
-    self: *Poll,
+    poll: *Poll,
+    allocator: mem.Allocator,
     task: usize,
     socket: net.Socket.Handle,
     buffer: []u8,
 ) Errors.Recv!void {
-    try self.fd_list.append(self.allocator, .{
+    try poll.fd_list.append(allocator, .{
         .fd = socket,
         .events = syscall.POLL.IN,
         .revents = 0,
     });
-    try self.fd_job_map.put(socket, .{
+    try poll.fd_job_map.put(allocator, socket, .{
         .index = 0,
         .type = .{
             .recv = .{
@@ -216,17 +266,18 @@ fn queue_recv(
 }
 
 fn queue_send(
-    self: *Poll,
+    poll: *Poll,
+    allocator: mem.Allocator,
     task: usize,
     socket: net.Socket.Handle,
     buffer: []const u8,
 ) Errors.Send!void {
-    try self.fd_list.append(self.allocator, .{
+    try poll.fd_list.append(allocator, .{
         .fd = socket,
         .events = syscall.POLL.OUT,
         .revents = 0,
     });
-    try self.fd_job_map.put(socket, .{
+    try poll.fd_job_map.put(allocator, socket, .{
         .index = 0,
         .type = .{
             .send = .{
@@ -253,6 +304,7 @@ pub fn submit(_: *anyopaque) !void {}
 
 pub fn reap(
     runner: *anyopaque,
+    _: mem.Allocator,
     completions: []results.Completion,
     wait: bool,
 ) ![]results.Completion {
@@ -278,10 +330,15 @@ pub fn reap(
         var timeout: i96 = if (!wait or reaped > 0) 0 else -1;
 
         // Select next Timer
-        if (poll.timers.peek()) |peeked| timeout = @intCast(peeked.duration.nanoseconds - current.nanoseconds);
+        if (poll.timers.peek()) |peeked| timeout = @intCast(
+            peeked.duration.nanoseconds - current.nanoseconds,
+        );
 
         log.debug("timeout = {d}", .{timeout});
-        const poll_result = try syscall.poll(poll.fd_list.items, @intCast(@divFloor(timeout, std.time.ns_per_ms)));
+        const poll_result = try syscall.poll(
+            poll.fd_list.items,
+            @intCast(@divFloor(timeout, std.time.ns_per_ms)),
+        );
 
         if (poll_result == 0 and timeout > 0) continue :poll_loop;
 
@@ -452,9 +509,9 @@ pub fn reap(
     return completions[0..reaped];
 }
 
-pub fn to_async(self: *Poll) AsyncIO {
+pub fn to_async(poll: *Poll) AsyncIO {
     return .{
-        .runner = self,
+        .runner = poll,
         .features = .init(&.{
             .timer,
             .accept,

--- a/src/aio/Poll.zig
+++ b/src/aio/Poll.zig
@@ -43,7 +43,7 @@ pub fn init(allocator: mem.Allocator, options: AsyncIO.Options) !Poll {
                 &binded_addr,
                 &binded_size,
             );
-            const bounded_addr = net.Socket.Address.fromAny(&binded_addr);
+            const bounded_addr: net.Socket.Address = .fromAny(&binded_addr);
 
             try syscall.connect(write_end, &bounded_addr);
 
@@ -129,35 +129,35 @@ pub fn queue_job(
     const poll: *Poll = @ptrCast(@alignCast(runner));
 
     try switch (job) {
-        .timer => |inner| poll.queue_timer(
+        .timer => |timer| poll.queue_timer(
             allocator,
             task,
-            inner,
+            timer,
         ),
-        .accept => |inner| poll.queue_accept(
+        .accept => |accept| poll.queue_accept(
             allocator,
             task,
-            inner.socket,
-            inner.kind,
+            accept.socket,
+            accept.kind,
         ),
-        .connect => |inner| poll.queue_connect(
+        .connect => |connect| poll.queue_connect(
             allocator,
             task,
-            inner.socket,
-            inner.addr,
-            inner.kind,
+            connect.socket,
+            connect.addr,
+            connect.kind,
         ),
-        .recv => |inner| poll.queue_recv(
+        .recv => |recv| poll.queue_recv(
             allocator,
             task,
-            inner.socket,
-            inner.buffer,
+            recv.socket,
+            recv.buffer,
         ),
-        .send => |inner| poll.queue_send(
+        .send => |send| poll.queue_send(
             allocator,
             task,
-            inner.socket,
-            inner.buffer,
+            send.socket,
+            send.buffer,
         ),
         .open, .delete, .mkdir, .stat, .read, .write, .close => unreachable,
     };
@@ -370,14 +370,14 @@ pub fn reap(
                         remove = false;
                         break :result .wake;
                     },
-                    .accept => |*inner| {
+                    .accept => |*accept| {
                         debug.assert(pfd.revents & syscall.POLL.IN != 0 or
                             pfd.revents & syscall.POLL.RDNORM != 0);
 
                         const AcceptError = results.AcceptError;
                         const socket = syscall.accept(
-                            inner.socket,
-                            &inner.addr,
+                            accept.socket,
+                            &accept.addr,
                             if (native_os != .windows) posix.SOCK.NONBLOCK else 0,
                         ) catch |e| {
                             const err = switch (e) {
@@ -406,8 +406,8 @@ pub fn reap(
                             .accept = .{
                                 .actual = .{
                                     .handle = socket,
-                                    .addr = inner.addr,
-                                    .kind = inner.kind,
+                                    .addr = accept.addr,
+                                    .kind = accept.kind,
                                 },
                             },
                         };
@@ -425,7 +425,7 @@ pub fn reap(
                             };
                         }
                     },
-                    .recv => |inner| {
+                    .recv => |recv| {
                         if (pfd.revents & syscall.POLL.HUP != 0) break :result .{
                             .recv = .{
                                 .err = results.RecvError.Closed,
@@ -437,8 +437,8 @@ pub fn reap(
 
                         const RecvError = results.RecvError;
                         const count = syscall.recv(
-                            inner.socket,
-                            inner.buffer,
+                            recv.socket,
+                            recv.buffer,
                             0,
                         ) catch |e| {
                             const err = switch (e) {
@@ -468,7 +468,7 @@ pub fn reap(
                             .actual = count,
                         } };
                     },
-                    .send => |inner| {
+                    .send => |send| {
                         const SendError = results.SendError;
                         if (pfd.revents & syscall.POLL.HUP != 0) break :result .{
                             .send = .{
@@ -478,8 +478,8 @@ pub fn reap(
 
                         debug.assert(pfd.revents & syscall.POLL.OUT != 0);
                         const count = syscall.send(
-                            inner.socket,
-                            inner.buffer,
+                            send.socket,
+                            send.buffer,
                             0,
                         ) catch |e| {
                             log.err("send failed with {}", .{e});

--- a/src/aio/results.zig
+++ b/src/aio/results.zig
@@ -193,7 +193,7 @@ pub const SendResult = Resulted(usize, SendError);
 // This is ONLY used internally. This helps us avoid Result enum bloat
 // by encoding multiple possibilities within one Result.
 const OpenResultType = union(enum) { file: fs.File, dir: fs.Dir };
-pub const InnerOpenResult = Resulted(OpenResultType, OpenError);
+pub const OpenResult = Resulted(OpenResultType, OpenError);
 pub const OpenFileResult = Resulted(fs.File, OpenError);
 pub const OpenDirResult = Resulted(fs.Dir, OpenError);
 
@@ -220,7 +220,7 @@ pub const Result = union(enum) {
     connect: ConnectResult,
     recv: RecvResult,
     send: SendResult,
-    open: InnerOpenResult,
+    open: OpenResult,
     mkdir: MkdirResult,
     delete: DeleteResult,
     read: ReadResult,

--- a/src/aio/results.zig
+++ b/src/aio/results.zig
@@ -6,12 +6,12 @@ const Socket = tardy.net.Socket;
 
 pub fn Resulted(comptime T: type, comptime E: type) type {
     return union(enum) {
-        const Self = @This();
+        const Resulted_t = @This();
         actual: T,
         err: E,
 
-        pub fn unwrap(self: *const Self) E!T {
-            switch (self.*) {
+        pub fn unwrap(result: *const Resulted_t) E!T {
+            switch (result.*) {
                 .actual => |a| return a,
                 .err => |e| return e,
             }

--- a/src/channel/spsc.zig
+++ b/src/channel/spsc.zig
@@ -2,91 +2,6 @@ pub fn Spsc(comptime T: type) type {
     return struct {
         const Spsc_t = @This();
 
-        fn trigger_consumer(spsc: *Spsc_t) !void {
-            try spsc.consumer_rt.load(.acquire).?.trigger(
-                spsc.consumer_index.load(.acquire),
-            );
-        }
-
-        fn trigger_producer(spsc: *Spsc_t) !void {
-            try spsc.producer_rt.load(.acquire).?.trigger(
-                spsc.producer_index.load(.acquire),
-            );
-        }
-
-        pub const Producer = struct {
-            inner: *Spsc_t,
-            rt: *Runtime,
-
-            pub fn send(spsc: Producer, message: T) !void {
-                log.debug("producer sending...", .{});
-                while (true) switch (spsc.inner.state.load(.acquire)) {
-                    // Both ends must be open.
-                    .starting => spsc.rt.scheduler.trigger_await(),
-                    // Channel was cleaned up.
-                    .closed => return error.Closed,
-                    .running => {
-                        if (!spsc.inner.consumer_open.load(.acquire)) return error.Closed;
-                        spsc.inner.ring.push(message) catch |e| switch (e) {
-                            error.RingFull => {
-                                spsc.inner.producer_index.store(
-                                    spsc.rt.current_task.?,
-                                    .release,
-                                );
-                                try spsc.inner.trigger_consumer();
-                                spsc.rt.scheduler.trigger_await();
-                                continue;
-                            },
-                        };
-
-                        return;
-                    },
-                };
-            }
-
-            pub fn close(spsc: Producer) void {
-                spsc.inner.producer_open.store(false, .release);
-                spsc.inner.trigger_consumer() catch unreachable;
-            }
-        };
-
-        pub const Consumer = struct {
-            inner: *Spsc_t,
-            rt: *Runtime,
-
-            pub fn recv(spsc: Consumer) !T {
-                log.debug("consumer recving...", .{});
-                while (true) switch (spsc.inner.state.load(.acquire)) {
-                    // Both ends must be open.
-                    .starting => spsc.rt.scheduler.trigger_await(),
-                    // Channel was cleaned up.
-                    .closed => return error.Closed,
-                    .running => {
-                        const data = spsc.inner.ring.pop() catch |e| switch (e) {
-                            // If we are empty, trigger the producer to run.
-                            error.RingEmpty => {
-                                if (!spsc.inner.producer_open.load(.acquire)) return error.Closed;
-                                spsc.inner.consumer_index.store(
-                                    spsc.rt.current_task.?,
-                                    .release,
-                                );
-                                try spsc.inner.trigger_producer();
-                                spsc.rt.scheduler.trigger_await();
-                                continue;
-                            },
-                        };
-
-                        return data;
-                    },
-                };
-            }
-
-            pub fn close(spsc: Consumer) void {
-                spsc.inner.consumer_open.store(false, .release);
-                spsc.inner.trigger_producer() catch unreachable;
-            }
-        };
-
         ring: atomic.SpscRing(T),
 
         producer_rt: std_atomic.Value(?*Runtime) align(std_atomic.cache_line),
@@ -97,7 +12,7 @@ pub fn Spsc(comptime T: type) type {
         consumer_index: std_atomic.Value(usize) align(std_atomic.cache_line),
         consumer_open: std_atomic.Value(bool) align(std_atomic.cache_line),
 
-        state: std.atomic.Value(State) align(std_atomic.cache_line),
+        state: std_atomic.Value(State) align(std_atomic.cache_line),
 
         pub fn init(allocator: std.mem.Allocator, size: usize) !Spsc_t {
             return .{
@@ -118,7 +33,12 @@ pub fn Spsc(comptime T: type) type {
             spsc.producer_open.store(false, .release);
             spsc.consumer_open.store(false, .release);
 
-            if (spsc.state.cmpxchgStrong(.running, .closed, .acq_rel, .acquire)) |_| {
+            if (spsc.state.cmpxchgStrong(
+                .running,
+                .closed,
+                .acq_rel,
+                .acquire,
+            )) |_| {
                 return; // Someone else is handling deinit
             }
 
@@ -138,7 +58,7 @@ pub fn Spsc(comptime T: type) type {
                 .running,
                 .release,
             );
-            return .{ .inner = spsc, .rt = runtime };
+            return .{ .producer = spsc, .rt = runtime };
         }
 
         pub fn consumer(spsc: *Spsc_t, runtime: *Runtime) Consumer {
@@ -154,8 +74,95 @@ pub fn Spsc(comptime T: type) type {
                 .running,
                 .release,
             );
-            return .{ .inner = spsc, .rt = runtime };
+            return .{ .consumer = spsc, .rt = runtime };
         }
+
+        fn trigger_consumer(spsc: *Spsc_t) !void {
+            try spsc.consumer_rt.load(.acquire).?.trigger(
+                spsc.consumer_index.load(.acquire),
+            );
+        }
+
+        fn trigger_producer(spsc: *Spsc_t) !void {
+            try spsc.producer_rt.load(.acquire).?.trigger(
+                spsc.producer_index.load(.acquire),
+            );
+        }
+
+        pub const Producer = struct {
+            producer: *Spsc_t,
+            rt: *Runtime,
+
+            pub fn send(spsc: Producer, message: T) !void {
+                log.debug("producer sending...", .{});
+                while (true) switch (spsc.producer.state.load(.acquire)) {
+                    // Both ends must be open.
+                    .starting => spsc.rt.scheduler.trigger_await(),
+                    // Channel was cleaned up.
+                    .closed => return error.Closed,
+                    .running => {
+                        if (!spsc.producer.consumer_open.load(.acquire))
+                            return error.Closed;
+                        spsc.producer.ring.push(message) catch |e| switch (e) {
+                            error.RingFull => {
+                                spsc.producer.producer_index.store(
+                                    spsc.rt.current_task.?,
+                                    .release,
+                                );
+                                try spsc.producer.trigger_consumer();
+                                spsc.rt.scheduler.trigger_await();
+                                continue;
+                            },
+                        };
+
+                        return;
+                    },
+                };
+            }
+
+            pub fn close(spsc: Producer) void {
+                spsc.producer.producer_open.store(false, .release);
+                spsc.producer.trigger_consumer() catch unreachable;
+            }
+        };
+
+        pub const Consumer = struct {
+            consumer: *Spsc_t,
+            rt: *Runtime,
+
+            pub fn recv(spsc: Consumer) !T {
+                log.debug("consumer recving...", .{});
+                while (true) switch (spsc.consumer.state.load(.acquire)) {
+                    // Both ends must be open.
+                    .starting => spsc.rt.scheduler.trigger_await(),
+                    // Channel was cleaned up.
+                    .closed => return error.Closed,
+                    .running => {
+                        const data = spsc.consumer.ring.pop() catch |e| switch (e) {
+                            // If we are empty, trigger the producer to run.
+                            error.RingEmpty => {
+                                if (!spsc.consumer.producer_open.load(.acquire))
+                                    return error.Closed;
+                                spsc.consumer.consumer_index.store(
+                                    spsc.rt.current_task.?,
+                                    .release,
+                                );
+                                try spsc.consumer.trigger_producer();
+                                spsc.rt.scheduler.trigger_await();
+                                continue;
+                            },
+                        };
+
+                        return data;
+                    },
+                };
+            }
+
+            pub fn close(spsc: Consumer) void {
+                spsc.consumer.consumer_open.store(false, .release);
+                spsc.consumer.trigger_producer() catch unreachable;
+            }
+        };
     };
 }
 

--- a/src/channel/spsc.zig
+++ b/src/channel/spsc.zig
@@ -1,40 +1,40 @@
 pub fn Spsc(comptime T: type) type {
     return struct {
-        const Self = @This();
+        const Spsc_t = @This();
 
-        fn trigger_consumer(self: *Self) !void {
-            try self.consumer_rt.load(.acquire).?.trigger(
-                self.consumer_index.load(.acquire),
+        fn trigger_consumer(spsc: *Spsc_t) !void {
+            try spsc.consumer_rt.load(.acquire).?.trigger(
+                spsc.consumer_index.load(.acquire),
             );
         }
 
-        fn trigger_producer(self: *Self) !void {
-            try self.producer_rt.load(.acquire).?.trigger(
-                self.producer_index.load(.acquire),
+        fn trigger_producer(spsc: *Spsc_t) !void {
+            try spsc.producer_rt.load(.acquire).?.trigger(
+                spsc.producer_index.load(.acquire),
             );
         }
 
         pub const Producer = struct {
-            inner: *Self,
+            inner: *Spsc_t,
             rt: *Runtime,
 
-            pub fn send(self: Producer, message: T) !void {
+            pub fn send(spsc: Producer, message: T) !void {
                 log.debug("producer sending...", .{});
-                while (true) switch (self.inner.state.load(.acquire)) {
+                while (true) switch (spsc.inner.state.load(.acquire)) {
                     // Both ends must be open.
-                    .starting => self.rt.scheduler.trigger_await(),
+                    .starting => spsc.rt.scheduler.trigger_await(),
                     // Channel was cleaned up.
                     .closed => return error.Closed,
                     .running => {
-                        if (!self.inner.consumer_open.load(.acquire)) return error.Closed;
-                        self.inner.ring.push(message) catch |e| switch (e) {
+                        if (!spsc.inner.consumer_open.load(.acquire)) return error.Closed;
+                        spsc.inner.ring.push(message) catch |e| switch (e) {
                             error.RingFull => {
-                                self.inner.producer_index.store(
-                                    self.rt.current_task.?,
+                                spsc.inner.producer_index.store(
+                                    spsc.rt.current_task.?,
                                     .release,
                                 );
-                                try self.inner.trigger_consumer();
-                                self.rt.scheduler.trigger_await();
+                                try spsc.inner.trigger_consumer();
+                                spsc.rt.scheduler.trigger_await();
                                 continue;
                             },
                         };
@@ -44,34 +44,34 @@ pub fn Spsc(comptime T: type) type {
                 };
             }
 
-            pub fn close(self: Producer) void {
-                self.inner.producer_open.store(false, .release);
-                self.inner.trigger_consumer() catch unreachable;
+            pub fn close(spsc: Producer) void {
+                spsc.inner.producer_open.store(false, .release);
+                spsc.inner.trigger_consumer() catch unreachable;
             }
         };
 
         pub const Consumer = struct {
-            inner: *Self,
+            inner: *Spsc_t,
             rt: *Runtime,
 
-            pub fn recv(self: Consumer) !T {
+            pub fn recv(spsc: Consumer) !T {
                 log.debug("consumer recving...", .{});
-                while (true) switch (self.inner.state.load(.acquire)) {
+                while (true) switch (spsc.inner.state.load(.acquire)) {
                     // Both ends must be open.
-                    .starting => self.rt.scheduler.trigger_await(),
+                    .starting => spsc.rt.scheduler.trigger_await(),
                     // Channel was cleaned up.
                     .closed => return error.Closed,
                     .running => {
-                        const data = self.inner.ring.pop() catch |e| switch (e) {
+                        const data = spsc.inner.ring.pop() catch |e| switch (e) {
                             // If we are empty, trigger the producer to run.
                             error.RingEmpty => {
-                                if (!self.inner.producer_open.load(.acquire)) return error.Closed;
-                                self.inner.consumer_index.store(
-                                    self.rt.current_task.?,
+                                if (!spsc.inner.producer_open.load(.acquire)) return error.Closed;
+                                spsc.inner.consumer_index.store(
+                                    spsc.rt.current_task.?,
                                     .release,
                                 );
-                                try self.inner.trigger_producer();
-                                self.rt.scheduler.trigger_await();
+                                try spsc.inner.trigger_producer();
+                                spsc.rt.scheduler.trigger_await();
                                 continue;
                             },
                         };
@@ -81,9 +81,9 @@ pub fn Spsc(comptime T: type) type {
                 };
             }
 
-            pub fn close(self: Consumer) void {
-                self.inner.consumer_open.store(false, .release);
-                self.inner.trigger_producer() catch unreachable;
+            pub fn close(spsc: Consumer) void {
+                spsc.inner.consumer_open.store(false, .release);
+                spsc.inner.trigger_producer() catch unreachable;
             }
         };
 
@@ -99,7 +99,7 @@ pub fn Spsc(comptime T: type) type {
 
         state: std.atomic.Value(State) align(std_atomic.cache_line),
 
-        pub fn init(allocator: std.mem.Allocator, size: usize) !Self {
+        pub fn init(allocator: std.mem.Allocator, size: usize) !Spsc_t {
             return .{
                 .ring = try .init(allocator, size),
 
@@ -114,47 +114,47 @@ pub fn Spsc(comptime T: type) type {
             };
         }
 
-        pub fn deinit(self: *Self) void {
-            self.producer_open.store(false, .release);
-            self.consumer_open.store(false, .release);
+        pub fn deinit(spsc: *Spsc_t) void {
+            spsc.producer_open.store(false, .release);
+            spsc.consumer_open.store(false, .release);
 
-            if (self.state.cmpxchgStrong(.running, .closed, .acq_rel, .acquire)) |_| {
+            if (spsc.state.cmpxchgStrong(.running, .closed, .acq_rel, .acquire)) |_| {
                 return; // Someone else is handling deinit
             }
 
-            self.ring.deinit();
+            spsc.ring.deinit();
         }
 
-        pub fn producer(self: *Self, runtime: *Runtime) Producer {
-            if (self.producer_rt.cmpxchgStrong(
+        pub fn producer(spsc: *Spsc_t, runtime: *Runtime) Producer {
+            if (spsc.producer_rt.cmpxchgStrong(
                 null,
                 runtime,
                 .acq_rel,
                 .acquire,
             )) |_| @panic("Only one producer can exist for a Spsc");
 
-            self.producer_open.store(true, .release);
-            if (self.consumer_rt.load(.acquire) != null) self.state.store(
+            spsc.producer_open.store(true, .release);
+            if (spsc.consumer_rt.load(.acquire) != null) spsc.state.store(
                 .running,
                 .release,
             );
-            return .{ .inner = self, .rt = runtime };
+            return .{ .inner = spsc, .rt = runtime };
         }
 
-        pub fn consumer(self: *Self, runtime: *Runtime) Consumer {
-            if (self.consumer_rt.cmpxchgStrong(
+        pub fn consumer(spsc: *Spsc_t, runtime: *Runtime) Consumer {
+            if (spsc.consumer_rt.cmpxchgStrong(
                 null,
                 runtime,
                 .acq_rel,
                 .acquire,
             )) |_| @panic("Only one consumer can exist for a Spsc");
 
-            self.consumer_open.store(true, .release);
-            if (self.producer_rt.load(.acquire) != null) self.state.store(
+            spsc.consumer_open.store(true, .release);
+            if (spsc.producer_rt.load(.acquire) != null) spsc.state.store(
                 .running,
                 .release,
             );
-            return .{ .inner = self, .rt = runtime };
+            return .{ .inner = spsc, .rt = runtime };
         }
     };
 }

--- a/src/channel/spsc.zig
+++ b/src/channel/spsc.zig
@@ -114,7 +114,7 @@ pub fn Spsc(comptime T: type) type {
             };
         }
 
-        pub fn deinit(spsc: *Spsc_t) void {
+        pub fn deinit(spsc: *Spsc_t, allocator: mem.Allocator) void {
             spsc.producer_open.store(false, .release);
             spsc.consumer_open.store(false, .release);
 
@@ -122,7 +122,7 @@ pub fn Spsc(comptime T: type) type {
                 return; // Someone else is handling deinit
             }
 
-            spsc.ring.deinit();
+            spsc.ring.deinit(allocator);
         }
 
         pub fn producer(spsc: *Spsc_t, runtime: *Runtime) Producer {
@@ -168,6 +168,7 @@ const State = enum(u8) {
 };
 
 const std = @import("std");
+const mem = std.mem;
 const std_atomic = std.atomic;
 
 const tardy = @import("../root.zig");

--- a/src/core/Queue.zig
+++ b/src/core/Queue.zig
@@ -3,32 +3,31 @@ pub fn Queue(comptime T: type) type {
     const Node = List.Node;
 
     return struct {
-        allocator: mem.Allocator,
         items: List,
 
         pub fn init(allocator: mem.Allocator) Queue {
-            return .{ .allocator = allocator, .items = List{} };
+            return .{ .allocator = allocator, .items = .{} };
         }
 
-        pub fn deinit(self: *Queue) void {
-            while (self.items.pop()) |node| self.allocator.destroy(node);
+        pub fn deinit(queue: *Queue, allocator: mem.Allocator) void {
+            while (queue.items.popLast()) |node| allocator.destroy(node);
         }
 
-        pub fn append(self: *Queue, item: T) !void {
-            const node = try self.allocator.create(Node);
+        pub fn append(queue: *Queue, allocator: mem.Allocator, item: T) !void {
+            const node = try allocator.create(Node);
             node.* = .{ .data = item };
-            self.items.append(node);
+            queue.items.append(node);
         }
 
-        pub fn pop(self: *Queue) ?T {
-            const node = self.items.popFirst() orelse return null;
-            defer self.allocator.destroy(node);
+        pub fn pop(queue: *Queue, allocator: mem.Allocator) ?T {
+            const node = queue.items.popFirst() orelse return null;
+            defer allocator.destroy(node);
             return node.data;
         }
 
-        pub fn pop_assert(self: *Queue) T {
-            const node = self.items.popFirst().?;
-            defer self.allocator.destroy(node);
+        pub fn pop_assert(queue: *Queue, allocator: mem.Allocator) T {
+            const node = queue.items.popFirst().?;
+            defer allocator.destroy(node);
             return node.data;
         }
     };

--- a/src/core/Ring.zig
+++ b/src/core/Ring.zig
@@ -1,8 +1,7 @@
 pub fn Ring(comptime T: type) type {
     return struct {
-        const Self = @This();
+        const Ring_t = @This();
 
-        allocator: mem.Allocator,
         items: []T,
         // This is where we will read off of.
         read_index: usize = 0,
@@ -11,62 +10,61 @@ pub fn Ring(comptime T: type) type {
         // Total count of elements.
         count: usize = 0,
 
-        pub fn init(allocator: mem.Allocator, size: usize) !Self {
+        pub fn init(allocator: mem.Allocator, size: usize) !Ring_t {
             debug.assert(size >= 1);
             const items = try allocator.alloc(T, size);
             return .{
-                .allocator = allocator,
                 .items = items,
             };
         }
 
-        pub fn deinit(self: Self) void {
-            self.allocator.free(self.items);
+        pub fn deinit(ring: Ring_t, allocator: mem.Allocator) void {
+            allocator.free(ring.items);
         }
 
-        pub fn full(self: Self) bool {
-            return self.count == self.items.len;
+        pub fn full(ring: Ring_t) bool {
+            return ring.count == ring.items.len;
         }
 
-        pub fn empty(self: Self) bool {
-            return self.count == 0;
+        pub fn empty(ring: Ring_t) bool {
+            return ring.count == 0;
         }
 
-        pub fn push(self: *Self, message: T) !void {
-            if (self.full()) return error.RingFull;
-            self.items[self.write_index] = message;
-            self.write_index = (self.write_index + 1) % self.items.len;
-            self.count += 1;
+        pub fn push(ring: *Ring_t, message: T) !void {
+            if (ring.full()) return error.RingFull;
+            ring.items[ring.write_index] = message;
+            ring.write_index = (ring.write_index + 1) % ring.items.len;
+            ring.count += 1;
         }
 
-        pub fn push_assert(self: *Self, message: T) void {
-            debug.assert(!self.full());
-            self.items[self.write_index] = message;
-            self.write_index = (self.write_index + 1) % self.items.len;
-            self.count += 1;
+        pub fn push_assert(ring: *Ring_t, message: T) void {
+            debug.assert(!ring.full());
+            ring.items[ring.write_index] = message;
+            ring.write_index = (ring.write_index + 1) % ring.items.len;
+            ring.count += 1;
         }
 
-        pub fn pop(self: *Self) !T {
-            if (self.empty()) return error.RingEmpty;
-            const message = self.items[self.read_index];
-            self.read_index = (self.read_index + 1) % self.items.len;
-            self.count -= 1;
+        pub fn pop(ring: *Ring_t) !T {
+            if (ring.empty()) return error.RingEmpty;
+            const message = ring.items[ring.read_index];
+            ring.read_index = (ring.read_index + 1) % ring.items.len;
+            ring.count -= 1;
             return message;
         }
 
-        pub fn pop_assert(self: *Self) T {
-            debug.assert(!self.empty());
-            const message = self.items[self.read_index];
-            self.read_index = (self.read_index + 1) % self.items.len;
-            self.count -= 1;
+        pub fn pop_assert(ring: *Ring_t) T {
+            debug.assert(!ring.empty());
+            const message = ring.items[ring.read_index];
+            ring.read_index = (ring.read_index + 1) % ring.items.len;
+            ring.count -= 1;
             return message;
         }
 
-        pub fn pop_ptr(self: *Self) !*T {
-            if (self.empty()) return error.RingEmpty;
-            const message = &self.items[self.read_index];
-            self.read_index = (self.read_index + 1) % self.items.len;
-            self.count -= 1;
+        pub fn pop_ptr(ring: *Ring_t) !*T {
+            if (ring.empty()) return error.RingEmpty;
+            const message = &ring.items[ring.read_index];
+            ring.read_index = (ring.read_index + 1) % ring.items.len;
+            ring.count -= 1;
             return message;
         }
     };
@@ -75,7 +73,7 @@ pub fn Ring(comptime T: type) type {
 test "Ring Send and Recv" {
     const size: u32 = 100;
     var ring: Ring(usize) = try .init(testing.allocator, size);
-    defer ring.deinit();
+    defer ring.deinit(testing.allocator);
 
     for (0..size) |i| {
         for (0..i) |j| {

--- a/src/core/ZeroCopy.zig
+++ b/src/core/ZeroCopy.zig
@@ -1,12 +1,11 @@
 pub fn ZeroCopy(comptime T: type) type {
     return struct {
-        const Self = @This();
-        allocator: mem.Allocator,
+        const ZeroCopy_t = @This();
         ptr: [*]T,
         len: usize,
         capacity: usize,
 
-        pub fn init(allocator: mem.Allocator, capacity: usize) !Self {
+        pub fn init(allocator: mem.Allocator, capacity: usize) !ZeroCopy_t {
             const slice = try allocator.alloc(T, capacity);
             return .{
                 .allocator = allocator,
@@ -16,26 +15,21 @@ pub fn ZeroCopy(comptime T: type) type {
             };
         }
 
-        pub fn deinit(self: *Self) void {
-            self.allocator.free(self.ptr[0..self.capacity]);
+        pub fn deinit(zc: *ZeroCopy_t, allocator: mem.Allocator) void {
+            allocator.free(zc.ptr[0..zc.capacity]);
         }
 
-        pub fn as_slice(self: *const Self) []T {
-            return self.ptr[0..self.len];
+        pub fn as_slice(zc: *const ZeroCopy_t) []T {
+            return zc.ptr[0..zc.len];
         }
 
-        const SubsliceOptions = struct {
-            start: ?usize = null,
-            end: ?usize = null,
-        };
-
-        pub fn subslice(self: *const Self, options: SubsliceOptions) []T {
+        pub fn subslice(zc: *const ZeroCopy_t, options: SubsliceOptions) []T {
             const start: usize = options.start orelse 0;
-            const end: usize = options.end orelse self.len;
+            const end: usize = options.end orelse zc.len;
             debug.assert(start <= end);
-            debug.assert(end <= self.len);
+            debug.assert(end <= zc.len);
 
-            return self.ptr[start..end];
+            return zc.ptr[start..end];
         }
 
         /// This returns a slice that you can write into for zero-copy uses.
@@ -43,92 +37,108 @@ pub fn ZeroCopy(comptime T: type) type {
         ///
         /// The write area that is returned is ONLY valid until the next call of
         /// `get_write_area` or mark_written.
-        pub fn get_write_area(self: *Self, size: usize) ![]T {
-            const available_space = self.capacity - self.len;
+        pub fn get_write_area(
+            zc: *ZeroCopy_t,
+            allocator: mem.Allocator,
+            size: usize,
+        ) ![]T {
+            const available_space = zc.capacity - zc.len;
             if (available_space >= size) {
-                return self.ptr[self.len .. self.len + size];
+                return zc.ptr[zc.len .. zc.len + size];
             } else {
-                const old_slice = self.ptr[0..self.capacity];
+                const old_slice = zc.ptr[0..zc.capacity];
                 const new_size = try std.math.ceilPowerOfTwo(
                     usize,
-                    self.capacity + size,
+                    zc.capacity + size,
                 );
 
-                if (self.allocator.remap(
-                    self.ptr[0..self.capacity],
+                if (allocator.remap(
+                    zc.ptr[0..zc.capacity],
                     new_size,
                 )) |new| {
-                    self.ptr = new.ptr;
-                    self.capacity = new.len;
-                } else if (self.allocator.resize(
-                    self.ptr[0..self.capacity],
+                    zc.ptr = new.ptr;
+                    zc.capacity = new.len;
+                } else if (allocator.resize(
+                    zc.ptr[0..zc.capacity],
                     new_size,
                 )) {
-                    self.capacity = new_size;
+                    zc.capacity = new_size;
                 } else {
-                    const new_slice = try self.allocator.alloc(T, new_size);
-                    @memcpy(new_slice[0..self.len], self.ptr[0..self.len]);
-                    self.allocator.free(old_slice);
+                    const new_slice = try allocator.alloc(T, new_size);
+                    @memcpy(new_slice[0..zc.len], zc.ptr[0..zc.len]);
+                    allocator.free(old_slice);
 
-                    self.ptr = new_slice.ptr;
-                    self.capacity = new_slice.len;
+                    zc.ptr = new_slice.ptr;
+                    zc.capacity = new_slice.len;
                 }
 
-                debug.assert(self.capacity - self.len >= size);
-                return self.ptr[self.len .. self.len + size];
+                debug.assert(zc.capacity - zc.len >= size);
+                return zc.ptr[zc.len .. zc.len + size];
             }
         }
 
-        pub fn get_write_area_assume_space(self: *const Self, size: usize) []T {
-            debug.assert(self.capacity - self.len >= size);
-            return self.ptr[self.len .. self.len + size];
+        pub fn get_write_area_assume_space(zc: *const ZeroCopy_t, size: usize) []T {
+            debug.assert(zc.capacity - zc.len >= size);
+            return zc.ptr[zc.len .. zc.len + size];
         }
 
-        pub fn mark_written(self: *Self, length: usize) void {
-            debug.assert(self.len + length <= self.capacity);
-            self.len += length;
+        pub fn mark_written(zc: *ZeroCopy_t, length: usize) void {
+            debug.assert(zc.len + length <= zc.capacity);
+            zc.len += length;
         }
 
-        pub fn shrink_retaining_capacity(self: *Self, new_size: usize) void {
-            debug.assert(new_size <= self.len);
-            self.len = new_size;
+        pub fn shrink_retaining_capacity(zc: *ZeroCopy_t, new_size: usize) void {
+            debug.assert(new_size <= zc.len);
+            zc.len = new_size;
         }
 
-        pub fn shrink_clear_and_free(self: *Self, new_size: usize) !void {
-            debug.assert(new_size <= self.len);
-            if (!self.allocator.resize(
-                self.ptr[0..self.capacity],
+        pub fn shrink_clear_and_free(
+            zc: *ZeroCopy_t,
+            allocator: mem.Allocator,
+            new_size: usize,
+        ) !void {
+            debug.assert(new_size <= zc.len);
+            if (!allocator.resize(
+                zc.ptr[0..zc.capacity],
                 new_size,
             )) {
-                const slice = try self.allocator.realloc(
-                    self.ptr[0..self.capacity],
+                const slice = try allocator.realloc(
+                    zc.ptr[0..zc.capacity],
                     new_size,
                 );
-                self.ptr = slice.ptr;
+                zc.ptr = slice.ptr;
             }
-            self.capacity = new_size;
-            self.len = 0;
+            zc.capacity = new_size;
+            zc.len = 0;
         }
 
-        pub fn clear_retaining_capacity(self: *Self) void {
-            self.len = 0;
+        pub fn clear_retaining_capacity(zc: *ZeroCopy_t) void {
+            zc.len = 0;
         }
 
-        pub fn clear_and_free(self: *Self) void {
-            self.allocator.free(self.ptr[0..self.capacity]);
-            self.len = 0;
-            self.capacity = 0;
+        pub fn clear_and_free(zc: *ZeroCopy_t, allocator: mem.Allocator) void {
+            allocator.free(zc.ptr[0..zc.capacity]);
+            zc.len = 0;
+            zc.capacity = 0;
         }
     };
 }
+
+const SubsliceOptions = struct {
+    start: ?usize = null,
+    end: ?usize = null,
+};
 
 test "ZeroCopy: First" {
     const garbage: [128]u8 = @splat(212);
 
     var zc: ZeroCopy(u8) = try .init(testing.allocator, 512);
-    defer zc.deinit();
+    defer zc.deinit(testing.allocator);
 
-    const write_area = try zc.get_write_area(garbage.len);
+    const write_area = try zc.get_write_area(
+        garbage.len,
+        testing.allocator,
+    );
     @memcpy(write_area, garbage[0..]);
     zc.mark_written(write_area.len);
 
@@ -141,40 +151,57 @@ test "ZeroCopy: First" {
 
 test "ZeroCopy: Growth" {
     var zc: ZeroCopy(u8) = try .init(testing.allocator, 16);
-    defer zc.deinit();
+    defer zc.deinit(testing.allocator);
 
     const large_data: [32]u8 = @splat(1);
-    const write_area = try zc.get_write_area(large_data.len);
+    const write_area = try zc.get_write_area(
+        testing.allocator,
+        large_data.len,
+    );
     @memcpy(write_area, &large_data);
     zc.mark_written(write_area.len);
 
     try testing.expect(zc.capacity >= 32);
-    try testing.expectEqualSlices(u8, large_data[0..], zc.as_slice());
+    try testing.expectEqualSlices(
+        u8,
+        large_data[0..],
+        zc.as_slice(),
+    );
 }
 
 test "ZeroCopy: Multiple Writes" {
     var zc: ZeroCopy(u8) = try .init(testing.allocator, 64);
-    defer zc.deinit();
+    defer zc.deinit(testing.allocator);
 
     const data1 = "Hello, ";
     const data2 = "World!";
 
-    const area1 = try zc.get_write_area(data1.len);
+    const area1 = try zc.get_write_area(
+        testing.allocator,
+        data1.len,
+    );
     @memcpy(area1, data1);
     zc.mark_written(area1.len);
 
-    const area2 = try zc.get_write_area(data2.len);
+    const area2 = try zc.get_write_area(
+        testing.allocator,
+        data2.len,
+    );
     @memcpy(area2, data2);
     zc.mark_written(area2.len);
 
-    try testing.expectEqualSlices(u8, "Hello, World!", zc.as_slice());
+    try testing.expectEqualSlices(
+        u8,
+        "Hello, World!",
+        zc.as_slice(),
+    );
 }
 
 test "ZeroCopy: Zero Size Write" {
     var zc: ZeroCopy(u8) = try .init(testing.allocator, 8);
-    defer zc.deinit();
+    defer zc.deinit(testing.allocator);
 
-    const area = try zc.get_write_area(0);
+    const area = try zc.get_write_area(testing.allocator, 0);
     try testing.expect(area.len == 0);
     zc.mark_written(0);
     try testing.expect(zc.len == 0);

--- a/src/core/ZeroCopy.zig
+++ b/src/core/ZeroCopy.zig
@@ -8,7 +8,6 @@ pub fn ZeroCopy(comptime T: type) type {
         pub fn init(allocator: mem.Allocator, capacity: usize) !ZeroCopy_t {
             const slice = try allocator.alloc(T, capacity);
             return .{
-                .allocator = allocator,
                 .ptr = slice.ptr,
                 .len = 0,
                 .capacity = capacity,
@@ -136,8 +135,8 @@ test "ZeroCopy: First" {
     defer zc.deinit(testing.allocator);
 
     const write_area = try zc.get_write_area(
-        garbage.len,
         testing.allocator,
+        garbage.len,
     );
     @memcpy(write_area, garbage[0..]);
     zc.mark_written(write_area.len);

--- a/src/core/atomic/Bitset.zig
+++ b/src/core/atomic/Bitset.zig
@@ -1,7 +1,6 @@
 /// An Atomic Dynamic Bitset
 pub const Bitset = @This();
 
-allocator: mem.Allocator,
 words: []atomic.Value(usize),
 lock: std.Io.RwLock,
 /// Not safe to access. Use `get_bit_length`.
@@ -19,37 +18,36 @@ pub fn init(allocator: mem.Allocator, size: usize, default: bool) !Bitset {
     for (words) |*word| word.* = .{ .raw = value };
 
     return .{
-        .allocator = allocator,
         .words = words,
         .lock = .init,
         .bit_length = size,
     };
 }
 
-pub fn deinit(self: *Bitset, allocator: mem.Allocator, io: std.Io) void {
-    self.lock.lockUncancelable(io);
-    defer self.lock.unlock(io);
+pub fn deinit(bitset: *Bitset, allocator: mem.Allocator, io: std.Io) void {
+    bitset.lock.lockUncancelable(io);
+    defer bitset.lock.unlock(io);
 
-    allocator.free(self.words);
+    allocator.free(bitset.words);
 }
 
 fn resize(
-    self: *Bitset,
+    bitset: *Bitset,
     allocator: mem.Allocator,
     io: std.Io,
     new_size: usize,
     default: bool,
 ) !void {
-    self.lock.lockUncancelable(io);
-    defer self.lock.unlock(io);
+    bitset.lock.lockUncancelable(io);
+    defer bitset.lock.unlock(io);
 
     const new_word_count = @divCeil(new_size, @bitSizeOf(usize));
-    debug.assert(new_word_count > self.words.len);
+    debug.assert(new_word_count > bitset.words.len);
 
     const value: usize = if (default) math.maxInt(usize) else 0;
-    const old_words = self.words;
-    if (allocator.resize(self.words, new_word_count)) {
-        for (self.words[old_words.len..]) |*word| word.* = .{
+    const old_words = bitset.words;
+    if (allocator.resize(bitset.words, new_word_count)) {
+        for (bitset.words[old_words.len..]) |*word| word.* = .{
             .raw = value,
         };
     } else {
@@ -62,77 +60,77 @@ fn resize(
         for (new_words[old_words.len..]) |*word| word.* = .{
             .raw = value,
         };
-        self.words = new_words;
-        self.bit_length = new_size;
+        bitset.words = new_words;
+        bitset.bit_length = new_size;
     }
 }
 
-pub fn is_empty(self: *Bitset, io: std.Io) bool {
-    self.lock.lockSharedUncancelable(io);
-    defer self.lock.unlockShared(io);
+pub fn is_empty(bitset: *Bitset, io: std.Io) bool {
+    bitset.lock.lockSharedUncancelable(io);
+    defer bitset.lock.unlockShared(io);
 
-    for (self.words) |*word| if (word.load(.acquire) != 0) return false;
+    for (bitset.words) |*word| if (word.load(.acquire) != 0) return false;
     return true;
 }
 
-pub fn get_bit_length(self: *Bitset, io: std.Io) usize {
-    self.lock.lockSharedUncancelable(io);
-    defer self.lock.unlockShared(io);
+pub fn get_bit_length(bitset: *Bitset, io: std.Io) usize {
+    bitset.lock.lockSharedUncancelable(io);
+    defer bitset.lock.unlockShared(io);
 
-    return self.bit_length;
+    return bitset.bit_length;
 }
 
-pub fn set(self: *Bitset, io: std.Io, index: usize) !void {
-    self.lock.lockSharedUncancelable(io);
-    defer self.lock.unlockShared(io);
+pub fn set(bitset: *Bitset, allocator: mem.Allocator, io: std.Io, index: usize) !void {
+    bitset.lock.lockSharedUncancelable(io);
+    defer bitset.lock.unlockShared(io);
 
-    if (index > self.bit_length) {
-        self.lock.unlockShared(io);
-        defer self.lock.lockSharedUncancelable(io);
+    if (index > bitset.bit_length) {
+        bitset.lock.unlockShared(io);
+        defer bitset.lock.lockSharedUncancelable(io);
 
-        try self.resize(
-            self.allocator,
+        try bitset.resize(
+            allocator,
             io,
             try math.ceilPowerOfTwo(usize, index),
             false,
         );
     }
-    debug.assert(self.bit_length >= index);
+    debug.assert(bitset.bit_length >= index);
 
     const word = index / @bitSizeOf(usize);
-    debug.assert(word < self.words.len);
+    debug.assert(word < bitset.words.len);
     const mask: usize = @as(usize, 1) << @intCast(@mod(index, @bitSizeOf(usize)));
-    _ = self.words[word].fetchOr(mask, .release);
+    _ = bitset.words[word].fetchOr(mask, .release);
 }
 
-pub fn is_set(self: *Bitset, io: std.Io, index: usize) bool {
-    self.lock.lockSharedUncancelable(io);
-    defer self.lock.unlockShared(io);
-    debug.assert(self.bit_length >= index);
+pub fn is_set(bitset: *Bitset, io: std.Io, index: usize) bool {
+    bitset.lock.lockSharedUncancelable(io);
+    defer bitset.lock.unlockShared(io);
+    debug.assert(bitset.bit_length >= index);
 
     const word = index / @bitSizeOf(usize);
-    debug.assert(word < self.words.len);
+    debug.assert(word < bitset.words.len);
     const mask: usize = @as(usize, 1) << @intCast(@mod(index, @bitSizeOf(usize)));
-    return (self.words[word].load(.acquire) & mask) != 0;
+    return (bitset.words[word].load(.acquire) & mask) != 0;
 }
 
-pub fn unset(self: *Bitset, io: std.Io, index: usize) void {
-    self.lock.lockSharedUncancelable(io);
-    defer self.lock.unlockShared(io);
-    debug.assert(self.bit_length >= index);
+pub fn unset(bitset: *Bitset, io: std.Io, index: usize) void {
+    bitset.lock.lockSharedUncancelable(io);
+    defer bitset.lock.unlockShared(io);
+    debug.assert(bitset.bit_length >= index);
 
     const word = index / @bitSizeOf(usize);
-    debug.assert(word < self.words.len);
+    debug.assert(word < bitset.words.len);
     var mask: usize = math.maxInt(usize);
     mask ^= @as(usize, 1) << @intCast(@mod(index, @bitSizeOf(usize)));
-    _ = self.words[word].fetchAnd(mask, .release);
+    _ = bitset.words[word].fetchAnd(mask, .release);
 }
 
-pub fn unset_all(self: *Bitset, io: std.Io) void {
-    self.lock.lockSharedUncancelable(io);
-    defer self.lock.unlockShared(io);
+pub fn unset_all(bitset: *Bitset, io: std.Io) void {
+    bitset.lock.lockSharedUncancelable(io);
+    defer bitset.lock.unlockShared(io);
 
-    for (self.words) |*word| word.store(0, .release);
+    for (bitset.words) |*word| word.store(0, .release);
 }
 
 const std = @import("std");

--- a/src/core/atomic/SpscRing.zig
+++ b/src/core/atomic/SpscRing.zig
@@ -1,15 +1,14 @@
 /// An Atomic Spsc Ring
 pub fn SpscRing(comptime T: type) type {
     return struct {
-        const Self = @This();
+        const SpscRing_t = @This();
 
-        allocator: mem.Allocator,
         items: []T,
 
         write_index: atomic.Value(usize) align(atomic.cache_line),
         read_index: atomic.Value(usize) align(atomic.cache_line),
 
-        pub fn init(allocator: mem.Allocator, size: usize) !Self {
+        pub fn init(allocator: mem.Allocator, size: usize) !SpscRing_t {
             debug.assert(size >= 2);
             debug.assert(std.math.isPowerOfTwo(size));
 
@@ -17,30 +16,32 @@ pub fn SpscRing(comptime T: type) type {
             errdefer allocator.free(items);
 
             return .{
-                .allocator = allocator,
                 .items = items,
                 .write_index = .{ .raw = 0 },
                 .read_index = .{ .raw = 0 },
             };
         }
 
-        pub fn deinit(self: Self) void {
-            self.allocator.free(self.items);
+        pub fn deinit(spsc_ring: SpscRing_t, allocator: mem.Allocator) void {
+            allocator.free(spsc_ring.items);
         }
 
-        pub fn push(self: *Self, item: T) !void {
-            const write = self.write_index.load(.acquire);
-            const next: usize = (write + 1) % self.items.len;
-            if (next == self.read_index.load(.acquire)) return error.RingFull;
-            self.items[write] = item;
-            self.write_index.store((write + 1) % self.items.len, .release);
+        pub fn push(spsc_ring: *SpscRing_t, item: T) !void {
+            const write = spsc_ring.write_index.load(.acquire);
+            const next: usize = (write + 1) % spsc_ring.items.len;
+            if (next == spsc_ring.read_index.load(.acquire)) return error.RingFull;
+            spsc_ring.items[write] = item;
+            spsc_ring.write_index.store(
+                (write + 1) % spsc_ring.items.len,
+                .release,
+            );
         }
 
-        pub fn pop(self: *Self) !T {
-            const read = self.read_index.load(.acquire);
-            if (read == self.write_index.load(.acquire)) return error.RingEmpty;
-            const item = self.items[read];
-            self.read_index.store((read + 1) % self.items.len, .release);
+        pub fn pop(spsc_ring: *SpscRing_t) !T {
+            const read = spsc_ring.read_index.load(.acquire);
+            if (read == spsc_ring.write_index.load(.acquire)) return error.RingEmpty;
+            const item = spsc_ring.items[read];
+            spsc_ring.read_index.store((read + 1) % spsc_ring.items.len, .release);
             return item;
         }
     };
@@ -49,13 +50,25 @@ pub fn SpscRing(comptime T: type) type {
 test "SpscRing: Fill and Empty" {
     const size: u32 = 128;
     var ring: SpscRing(usize) = try .init(testing.allocator, size);
-    defer ring.deinit();
+    defer ring.deinit(testing.allocator);
 
-    try testing.expectError(error.RingEmpty, ring.pop());
+    try testing.expectError(
+        error.RingEmpty,
+        ring.pop(),
+    );
     for (0..size - 1) |i| try ring.push(i);
-    try testing.expectError(error.RingFull, ring.push(1));
-    for (0..size - 1) |i| try testing.expectEqual(i, try ring.pop());
-    try testing.expectError(error.RingEmpty, ring.pop());
+    try testing.expectError(
+        error.RingFull,
+        ring.push(1),
+    );
+    for (0..size - 1) |i| try testing.expectEqual(
+        i,
+        try ring.pop(),
+    );
+    try testing.expectError(
+        error.RingEmpty,
+        ring.pop(),
+    );
 }
 
 const std = @import("std");

--- a/src/core/pool.zig
+++ b/src/core/pool.zig
@@ -1,13 +1,13 @@
 pub fn Pool(comptime T: type) type {
     return struct {
-        const Self = @This();
+        const Pool_t = @This();
         // Buffer for the Pool.
         items: []T,
         dirty: std.DynamicBitSetUnmanaged,
         kind: Kind,
 
         /// Initalizes our items buffer as undefined.
-        pub fn init(allocator: mem.Allocator, size: usize, kind: Kind) !Self {
+        pub fn init(allocator: mem.Allocator, size: usize, kind: Kind) !Pool_t {
             return .{
                 .items = try allocator.alloc(T, size),
                 .dirty = try .initEmpty(allocator, size),
@@ -15,14 +15,14 @@ pub fn Pool(comptime T: type) type {
             };
         }
 
-        pub fn deinit(pool: *Self, allocator: mem.Allocator) void {
+        pub fn deinit(pool: *Pool_t, allocator: mem.Allocator) void {
             allocator.free(pool.items);
             pool.dirty.deinit(allocator);
         }
 
         /// Deinitalizes our items buffer with a passed in hook.
         pub fn deinit_with_hook(
-            pool: *Self,
+            pool: *Pool_t,
             allocator: mem.Allocator,
             args: anytype,
             deinit_hook: ?*const fn (buffer: []T, args: @TypeOf(args)) void,
@@ -35,32 +35,32 @@ pub fn Pool(comptime T: type) type {
             pool.dirty.deinit(allocator);
         }
 
-        pub fn get(pool: *const Self, index: usize) T {
+        pub fn get(pool: *const Pool_t, index: usize) T {
             debug.assert(index < pool.items.len);
             return pool.items[index];
         }
 
-        pub fn get_ptr(pool: *const Self, index: usize) *T {
+        pub fn get_ptr(pool: *const Pool_t, index: usize) *T {
             debug.assert(index < pool.items.len);
             return &pool.items[index];
         }
 
         /// Is this empty?
-        pub fn empty(pool: *const Self) bool {
+        pub fn empty(pool: *const Pool_t) bool {
             return pool.dirty.count() == 0;
         }
 
         /// Is this full?
-        pub fn full(pool: *const Self) bool {
+        pub fn full(pool: *const Pool_t) bool {
             return pool.dirty.count() == pool.items.len;
         }
 
         /// Returns the number of clean (or available) slots.
-        pub fn clean(pool: *const Self) usize {
+        pub fn clean(pool: *const Pool_t) usize {
             return pool.items.len - pool.dirty.count();
         }
 
-        fn grow(pool: *Self, allocator: mem.Allocator) Error!void {
+        fn grow(pool: *Pool_t, allocator: mem.Allocator) Error!void {
             debug.assert(pool.kind == .grow);
 
             const old_slice = pool.items;
@@ -97,7 +97,7 @@ pub fn Pool(comptime T: type) type {
         /// If dynamic, this *might* grow the Pool.
         ///
         /// Returns the index into the Pool.
-        pub fn borrow(pool: *Self, allocator: mem.Allocator) Error!usize {
+        pub fn borrow(pool: *Pool_t, allocator: mem.Allocator) Error!usize {
             var iter = pool.dirty.iterator(.{
                 .kind = .unset,
             });
@@ -118,7 +118,7 @@ pub fn Pool(comptime T: type) type {
         /// Uses a provided hint value as the starting index.
         ///
         /// Returns the index into the Pool.
-        pub fn borrow_hint(pool: *Self, allocator: mem.Allocator, hint: usize) Error!usize {
+        pub fn borrow_hint(pool: *Pool_t, allocator: mem.Allocator, hint: usize) Error!usize {
             const length = pool.items.len;
             for (0..length) |i| {
                 const index = @mod(hint + i, length);
@@ -141,7 +141,7 @@ pub fn Pool(comptime T: type) type {
         /// Attempts to borrow at the given index.
         /// Asserts that it is an available slot.
         /// This will never grow the Pool.
-        pub fn borrow_assume_unset(pool: *Self, index: usize) usize {
+        pub fn borrow_assume_unset(pool: *Pool_t, index: usize) usize {
             debug.assert(!pool.dirty.isSet(index));
             pool.dirty.set(index);
             return index;
@@ -149,13 +149,13 @@ pub fn Pool(comptime T: type) type {
 
         /// Releases the item with the given index back to the Pool.
         /// Asserts that the given index was borrowed.
-        pub fn release(pool: *Self, index: usize) void {
+        pub fn release(pool: *Pool_t, index: usize) void {
             debug.assert(pool.dirty.isSet(index));
             pool.dirty.unset(index);
         }
 
         /// Returns an iterator over the taken values in the Pool.
-        pub fn iterator(pool: *const Self) Iterator {
+        pub fn iterator(pool: *const Pool_t) Iterator {
             const iter = pool.dirty.iterator(.{});
             return .{ .iter = iter, .items = pool.items };
         }

--- a/src/core/pool.zig
+++ b/src/core/pool.zig
@@ -1,29 +1,6 @@
 pub fn Pool(comptime T: type) type {
     return struct {
-        pub const Iterator = struct {
-            items: []T,
-            iter: std.DynamicBitSetUnmanaged.Iterator(.{
-                .kind = .set,
-                .direction = .forward,
-            }),
-
-            pub fn next(self: *Iterator) ?T {
-                const index = self.iter.next() orelse return null;
-                return self.items[index];
-            }
-
-            pub fn next_ptr(self: *Iterator) ?*T {
-                const index = self.iter.next() orelse return null;
-                return &self.items[index];
-            }
-
-            pub fn next_index(self: *Iterator) ?usize {
-                return self.iter.next();
-            }
-        };
-
         const Self = @This();
-        allocator: mem.Allocator,
         // Buffer for the Pool.
         items: []T,
         dirty: std.DynamicBitSetUnmanaged,
@@ -32,96 +9,108 @@ pub fn Pool(comptime T: type) type {
         /// Initalizes our items buffer as undefined.
         pub fn init(allocator: mem.Allocator, size: usize, kind: Kind) !Self {
             return .{
-                .allocator = allocator,
                 .items = try allocator.alloc(T, size),
                 .dirty = try .initEmpty(allocator, size),
                 .kind = kind,
             };
         }
 
-        pub fn deinit(self: *Self) void {
-            self.allocator.free(self.items);
-            self.dirty.deinit(self.allocator);
+        pub fn deinit(pool: *Self, allocator: mem.Allocator) void {
+            allocator.free(pool.items);
+            pool.dirty.deinit(allocator);
         }
 
         /// Deinitalizes our items buffer with a passed in hook.
         pub fn deinit_with_hook(
-            self: *Self,
+            pool: *Self,
+            allocator: mem.Allocator,
             args: anytype,
             deinit_hook: ?*const fn (buffer: []T, args: @TypeOf(args)) void,
         ) void {
             if (deinit_hook) |hook| {
-                @call(.auto, hook, .{ self.items, args });
+                @call(.auto, hook, .{ pool.items, args });
             }
 
-            self.allocator.free(self.items);
-            self.dirty.deinit(self.allocator);
+            allocator.free(pool.items);
+            pool.dirty.deinit(allocator);
         }
 
-        pub fn get(self: *const Self, index: usize) T {
-            debug.assert(index < self.items.len);
-            return self.items[index];
+        pub fn get(pool: *const Self, index: usize) T {
+            debug.assert(index < pool.items.len);
+            return pool.items[index];
         }
 
-        pub fn get_ptr(self: *const Self, index: usize) *T {
-            debug.assert(index < self.items.len);
-            return &self.items[index];
+        pub fn get_ptr(pool: *const Self, index: usize) *T {
+            debug.assert(index < pool.items.len);
+            return &pool.items[index];
         }
 
         /// Is this empty?
-        pub fn empty(self: *const Self) bool {
-            return self.dirty.count() == 0;
+        pub fn empty(pool: *const Self) bool {
+            return pool.dirty.count() == 0;
         }
 
         /// Is this full?
-        pub fn full(self: *const Self) bool {
-            return self.dirty.count() == self.items.len;
+        pub fn full(pool: *const Self) bool {
+            return pool.dirty.count() == pool.items.len;
         }
 
         /// Returns the number of clean (or available) slots.
-        pub fn clean(self: *const Self) usize {
-            return self.items.len - self.dirty.count();
+        pub fn clean(pool: *const Self) usize {
+            return pool.items.len - pool.dirty.count();
         }
 
-        fn grow(self: *Self) Error!void {
-            debug.assert(self.kind == .grow);
+        fn grow(pool: *Self, allocator: mem.Allocator) Error!void {
+            debug.assert(pool.kind == .grow);
 
-            const old_slice = self.items;
-            const new_size = std.math.ceilPowerOfTwoAssert(usize, self.items.len + 1);
+            const old_slice = pool.items;
+            const new_size = std.math.ceilPowerOfTwoAssert(
+                usize,
+                pool.items.len + 1,
+            );
 
-            if (self.allocator.remap(self.items, new_size)) |new_slice| {
-                self.items = new_slice;
-            } else if (self.allocator.resize(self.items, new_size)) {
-                self.items = self.items.ptr[0..new_size];
-            } else {
-                const new_slice = try self.allocator.alloc(T, new_size);
-                errdefer self.allocator.free(new_slice);
-                @memcpy(new_slice[0..self.items.len], self.items);
-                self.items = new_slice;
-                self.allocator.free(old_slice);
+            if (allocator.remap(pool.items, new_size)) |new_slice|
+                pool.items = new_slice
+            else if (allocator.resize(pool.items, new_size))
+                pool.items = pool.items.ptr[0..new_size]
+            else {
+                const new_slice = try allocator.alloc(T, new_size);
+                errdefer allocator.free(new_slice);
+
+                @memcpy(new_slice[0..pool.items.len], pool.items);
+
+                pool.items = new_slice;
+                allocator.free(old_slice);
             }
-            try self.dirty.resize(self.allocator, new_size, false);
 
-            debug.assert(self.items.len == new_size);
-            debug.assert(self.dirty.bit_length == new_size);
+            try pool.dirty.resize(
+                allocator,
+                new_size,
+                false,
+            );
+
+            debug.assert(pool.items.len == new_size);
+            debug.assert(pool.dirty.bit_length == new_size);
         }
 
         /// Linearly probes for an available slot in the pool.
         /// If dynamic, this *might* grow the Pool.
         ///
         /// Returns the index into the Pool.
-        pub fn borrow(self: *Self) Error!usize {
-            var iter = self.dirty.iterator(.{ .kind = .unset });
-            const index = iter.next() orelse switch (self.kind) {
+        pub fn borrow(pool: *Self, allocator: mem.Allocator) Error!usize {
+            var iter = pool.dirty.iterator(.{
+                .kind = .unset,
+            });
+            const index = iter.next() orelse switch (pool.kind) {
                 .static => return error.Full,
                 .grow => {
-                    const last_index = self.items.len;
-                    try self.grow();
-                    return self.borrow_assume_unset(last_index);
+                    const last_index = pool.items.len;
+                    try pool.grow(allocator);
+                    return pool.borrow_assume_unset(last_index);
                 },
             };
 
-            self.dirty.set(index);
+            pool.dirty.set(index);
             return index;
         }
 
@@ -129,22 +118,22 @@ pub fn Pool(comptime T: type) type {
         /// Uses a provided hint value as the starting index.
         ///
         /// Returns the index into the Pool.
-        pub fn borrow_hint(self: *Self, hint: usize) Error!usize {
-            const length = self.items.len;
+        pub fn borrow_hint(pool: *Self, allocator: mem.Allocator, hint: usize) Error!usize {
+            const length = pool.items.len;
             for (0..length) |i| {
                 const index = @mod(hint + i, length);
-                if (!self.dirty.isSet(index)) {
-                    self.dirty.set(index);
+                if (!pool.dirty.isSet(index)) {
+                    pool.dirty.set(index);
                     return index;
                 }
             }
 
-            switch (self.kind) {
+            switch (pool.kind) {
                 .static => return error.Full,
                 .grow => {
-                    const last_index = self.items.len;
-                    try self.grow();
-                    return self.borrow_assume_unset(last_index);
+                    const last_index = pool.items.len;
+                    try pool.grow(allocator);
+                    return pool.borrow_assume_unset(last_index);
                 },
             }
         }
@@ -152,33 +141,62 @@ pub fn Pool(comptime T: type) type {
         /// Attempts to borrow at the given index.
         /// Asserts that it is an available slot.
         /// This will never grow the Pool.
-        pub fn borrow_assume_unset(self: *Self, index: usize) usize {
-            debug.assert(!self.dirty.isSet(index));
-            self.dirty.set(index);
+        pub fn borrow_assume_unset(pool: *Self, index: usize) usize {
+            debug.assert(!pool.dirty.isSet(index));
+            pool.dirty.set(index);
             return index;
         }
 
         /// Releases the item with the given index back to the Pool.
         /// Asserts that the given index was borrowed.
-        pub fn release(self: *Self, index: usize) void {
-            debug.assert(self.dirty.isSet(index));
-            self.dirty.unset(index);
+        pub fn release(pool: *Self, index: usize) void {
+            debug.assert(pool.dirty.isSet(index));
+            pool.dirty.unset(index);
         }
 
         /// Returns an iterator over the taken values in the Pool.
-        pub fn iterator(self: *const Self) Iterator {
-            const iter = self.dirty.iterator(.{});
-            return .{ .iter = iter, .items = self.items };
+        pub fn iterator(pool: *const Self) Iterator {
+            const iter = pool.dirty.iterator(.{});
+            return .{ .iter = iter, .items = pool.items };
         }
+
+        pub const Iterator = struct {
+            items: []T,
+            iter: std.DynamicBitSetUnmanaged.Iterator(.{
+                .kind = .set,
+                .direction = .forward,
+            }),
+
+            pub fn next(iter: *Iterator) ?T {
+                const index = iter.iter.next() orelse return null;
+                return iter.items[index];
+            }
+
+            pub fn next_ptr(iter: *Iterator) ?*T {
+                const index = iter.iter.next() orelse return null;
+                return &iter.items[index];
+            }
+
+            pub fn next_index(iter: *Iterator) ?usize {
+                return iter.iter.next();
+            }
+        };
     };
 }
 
 test "Pool: Initalization (integer)" {
-    var byte_pool: Pool(u8) = try .init(testing.allocator, 1024, .static);
-    defer byte_pool.deinit();
+    var byte_pool: Pool(u8) = try .init(
+        testing.allocator,
+        1024,
+        .static,
+    );
+    defer byte_pool.deinit(testing.allocator);
 
     for (0..1024) |i| {
-        const index = try byte_pool.borrow_hint(i);
+        const index = try byte_pool.borrow_hint(
+            testing.allocator,
+            i,
+        );
         const byte_ptr = byte_pool.get_ptr(index);
         byte_ptr.* = 2;
     }
@@ -189,13 +207,20 @@ test "Pool: Initalization (integer)" {
 }
 
 test "Pool: Dynamic Growth (integer)" {
-    var byte_pool: Pool(u8) = try .init(testing.allocator, 1, .grow);
-    defer byte_pool.deinit();
+    var byte_pool: Pool(u8) = try .init(
+        testing.allocator,
+        1,
+        .grow,
+    );
+    defer byte_pool.deinit(testing.allocator);
 
     const count = 1024;
 
     for (0..count) |i| {
-        const index = try byte_pool.borrow_hint(i);
+        const index = try byte_pool.borrow_hint(
+            testing.allocator,
+            i,
+        );
         const byte_ptr = byte_pool.get_ptr(index);
         byte_ptr.* = 2;
     }
@@ -208,8 +233,12 @@ test "Pool: Dynamic Growth (integer)" {
 }
 
 test "Pool: Initalization & Deinit (ArrayList)" {
-    var list_pool: Pool(std.ArrayList(u8)) = try .init(testing.allocator, 256, .static);
-    defer list_pool.deinit();
+    var list_pool: Pool(std.ArrayList(u8)) = try .init(
+        testing.allocator,
+        256,
+        .static,
+    );
+    defer list_pool.deinit(testing.allocator);
 
     for (list_pool.items, 0..) |*item, i| {
         item.* = .empty;
@@ -226,8 +255,12 @@ test "Pool: Initalization & Deinit (ArrayList)" {
 }
 
 test "Pool: BufferPool ([][]u8)" {
-    var buffer_pool: Pool([1024]u8) = try .init(testing.allocator, 1024, .static);
-    defer buffer_pool.deinit();
+    var buffer_pool: Pool([1024]u8) = try .init(
+        testing.allocator,
+        1024,
+        .static,
+    );
+    defer buffer_pool.deinit(testing.allocator);
 
     for (buffer_pool.items) |*item| {
         @memcpy(item[0..6], "ABCDEF");
@@ -239,15 +272,22 @@ test "Pool: BufferPool ([][]u8)" {
 }
 
 test "Pool: Borrowing" {
-    var byte_pool: Pool(u8) = try .init(testing.allocator, 1024, .static);
-    defer byte_pool.deinit();
+    var byte_pool: Pool(u8) = try .init(
+        testing.allocator,
+        1024,
+        .static,
+    );
+    defer byte_pool.deinit(testing.allocator);
 
     for (0..byte_pool.items.len) |_| {
-        _ = try byte_pool.borrow();
+        _ = try byte_pool.borrow(testing.allocator);
     }
 
     // Expect a Full.
-    try testing.expectError(error.Full, byte_pool.borrow());
+    try testing.expectError(
+        error.Full,
+        byte_pool.borrow(testing.allocator),
+    );
 
     for (0..byte_pool.items.len) |i| {
         byte_pool.release(i);
@@ -255,11 +295,15 @@ test "Pool: Borrowing" {
 }
 
 test "Pool: Borrowing Hint" {
-    var byte_pool: Pool(u8) = try .init(testing.allocator, 1024, .static);
-    defer byte_pool.deinit();
+    var byte_pool: Pool(u8) = try .init(
+        testing.allocator,
+        1024,
+        .static,
+    );
+    defer byte_pool.deinit(testing.allocator);
 
     for (0..byte_pool.items.len) |i| {
-        _ = try byte_pool.borrow_hint(i);
+        _ = try byte_pool.borrow_hint(testing.allocator, i);
     }
 
     for (0..byte_pool.items.len) |i| {
@@ -268,8 +312,12 @@ test "Pool: Borrowing Hint" {
 }
 
 test "Pool: Borrowing Unset" {
-    var byte_pool: Pool(u8) = try .init(testing.allocator, 1024, .static);
-    defer byte_pool.deinit();
+    var byte_pool: Pool(u8) = try .init(
+        testing.allocator,
+        1024,
+        .static,
+    );
+    defer byte_pool.deinit(testing.allocator);
 
     for (0..byte_pool.items.len) |i| {
         _ = byte_pool.borrow_assume_unset(i);
@@ -281,11 +329,15 @@ test "Pool: Borrowing Unset" {
 }
 
 test "Pool Iterator" {
-    var int_pool: Pool(usize) = try .init(testing.allocator, 1024, .static);
-    defer int_pool.deinit();
+    var int_pool: Pool(usize) = try .init(
+        testing.allocator,
+        1024,
+        .static,
+    );
+    defer int_pool.deinit(testing.allocator);
 
     for (0..(1024 / 2)) |_| {
-        const borrowed = try int_pool.borrow();
+        const borrowed = try int_pool.borrow(testing.allocator);
         const item_ptr = int_pool.get_ptr(borrowed);
         item_ptr.* = borrowed;
     }
@@ -299,7 +351,7 @@ test "Pool Iterator" {
     try testing.expect(int_pool.empty());
 }
 
-pub const Error = error{Full} || Allocator.Error;
+pub const Error = error{Full} || mem.Allocator.Error;
 
 pub const Kind = enum {
     /// This keeps the Pool at a static size, never growing.
@@ -312,4 +364,3 @@ const std = @import("std");
 const debug = std.debug;
 const testing = std.testing;
 const mem = std.mem;
-const Allocator = mem.Allocator;

--- a/src/cross.zig
+++ b/src/cross.zig
@@ -1,10 +1,5 @@
-/// Cross-platform abstractions.
-/// For the `std.posix` interface types.
-const std = @import("std");
-const File = std.Io.File;
-
-pub const fd = @import("cross/fd.zig");
-pub const socket = @import("cross/socket.zig");
+//! Cross-platform abstractions.
+//! For the `std.posix` interface types.
 
 /// Get the `fd_t` for `stdin`.
 pub fn get_std_in() std.posix.fd_t {
@@ -20,3 +15,9 @@ pub fn get_std_out() std.posix.fd_t {
 pub fn get_std_err() std.posix.fd_t {
     return File.stderr().handle;
 }
+
+const std = @import("std");
+const File = std.Io.File;
+
+pub const fd = @import("cross/fd.zig");
+pub const socket = @import("cross/socket.zig");

--- a/src/cross/fd.zig
+++ b/src/cross/fd.zig
@@ -1,13 +1,3 @@
-const std = @import("std");
-const builtin = @import("builtin");
-const os = builtin.os.tag;
-
-const tardy = @import("../root.zig");
-const syscall = tardy.AsyncIO.syscall;
-
-/// Invalid `fd_t`.
-pub const INVALID_FD = if (os == .windows) syscall.ws2.INVALID_SOCKET else -1;
-
 /// Ensures that the `std.posix.fd_t` is valid.
 pub fn is_valid(fd: std.posix.fd_t) bool {
     switch (comptime os) {
@@ -27,3 +17,16 @@ pub fn to_nonblock(fd: std.posix.fd_t) !void {
         _ = try syscall.fcntl(fd, std.posix.F.SETFL, arg);
     }
 }
+
+/// Invalid `fd_t`.
+pub const INVALID_FD = if (os == .windows)
+    syscall.ws2.INVALID_SOCKET
+else
+    -1;
+
+const std = @import("std");
+const builtin = @import("builtin");
+const os = builtin.os.tag;
+
+const tardy = @import("../root.zig");
+const syscall = tardy.AsyncIO.syscall;

--- a/src/cross/socket.zig
+++ b/src/cross/socket.zig
@@ -1,11 +1,3 @@
-const std = @import("std");
-const builtin = @import("builtin");
-const os = builtin.os.tag;
-
-const tardy = @import("../root.zig");
-const syscall = tardy.AsyncIO.syscall;
-pub const INVALID_SOCKET = @import("fd.zig").INVALID_FD;
-
 /// Ensures that the `std.posix.socket_t` is valid.
 pub fn is_valid(socket: std.posix.socket_t) bool {
     switch (comptime os) {
@@ -53,3 +45,11 @@ pub fn disable_nagle(socket: std.posix.socket_t) !void {
         );
     }
 }
+
+const std = @import("std");
+const builtin = @import("builtin");
+const os = builtin.os.tag;
+
+const tardy = @import("../root.zig");
+const syscall = tardy.AsyncIO.syscall;
+pub const INVALID_SOCKET = @import("fd.zig").INVALID_FD;

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -13,10 +13,14 @@ pub const Path = union(enum) {
     /// Absolute Path
     abs: [:0]const u8,
 
-    pub fn dupe(self: *const Path, allocator: std.mem.Allocator) !Path {
-        switch (self.*) {
+    pub fn dupe(path: *const Path, allocator: std.mem.Allocator) !Path {
+        switch (path.*) {
             .rel => |inner| {
-                const path_dupe = try allocator.dupeSentinel(u8, inner.path, 0x0);
+                const path_dupe = try allocator.dupeSentinel(
+                    u8,
+                    inner.path,
+                    0x0,
+                );
                 errdefer allocator.free(path_dupe);
                 return .{
                     .rel = .{
@@ -25,8 +29,12 @@ pub const Path = union(enum) {
                     },
                 };
             },
-            .abs => |path| return .{
-                .abs = try allocator.dupeSentinel(u8, path, 0x0),
+            .abs => |abs| return .{
+                .abs = try allocator.dupeSentinel(
+                    u8,
+                    abs,
+                    0x0,
+                ),
             },
         }
     }

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -15,16 +15,16 @@ pub const Path = union(enum) {
 
     pub fn dupe(path: *const Path, allocator: std.mem.Allocator) !Path {
         switch (path.*) {
-            .rel => |inner| {
+            .rel => |rel| {
                 const path_dupe = try allocator.dupeSentinel(
                     u8,
-                    inner.path,
+                    rel.path,
                     0x0,
                 );
                 errdefer allocator.free(path_dupe);
                 return .{
                     .rel = .{
-                        .dir = inner.dir,
+                        .dir = rel.dir,
                         .path = path_dupe,
                     },
                 };

--- a/src/fs/dir.zig
+++ b/src/fs/dir.zig
@@ -65,7 +65,11 @@ pub fn open(rt: *Runtime, path: fs.Path) !Dir {
             .rel => |inner| {
                 const dir: StdDir = .{ .handle = inner.dir };
 
-                const opened = dir.openDir(rt.io, inner.path, .{ .iterate = true }) catch |e| {
+                const opened = dir.openDir(
+                    rt.io,
+                    inner.path,
+                    .{ .iterate = true },
+                ) catch |e| {
                     return switch (e) {
                         StdDir.OpenError.AccessDenied => OpenError.AccessDenied,
                         else => OpenError.Unexpected,
@@ -75,7 +79,11 @@ pub fn open(rt: *Runtime, path: fs.Path) !Dir {
                 return .{ .handle = opened.handle };
             },
             .abs => |inner| {
-                const opened = Io.Dir.openDirAbsolute(rt.io, inner, .{ .iterate = true }) catch |e| {
+                const opened = Io.Dir.openDirAbsolute(
+                    rt.io,
+                    inner,
+                    .{ .iterate = true },
+                ) catch |e| {
                     return switch (e) {
                         StdDir.OpenError.AccessDenied => OpenError.AccessDenied,
                         else => OpenError.Unexpected,
@@ -105,7 +113,7 @@ pub fn create(rt: *Runtime, path: fs.Path) !Dir {
             else => |e| return e,
         };
 
-        return try Dir.open(rt, path);
+        return try .open(rt, path);
     } else {
         switch (path) {
             .rel => |p| {
@@ -117,7 +125,11 @@ pub fn create(rt: *Runtime, path: fs.Path) !Dir {
                 };
             },
             .abs => |p| {
-                Io.Dir.createDirAbsolute(rt.io, p, .default_dir) catch |e| {
+                Io.Dir.createDirAbsolute(
+                    rt.io,
+                    p,
+                    .default_dir,
+                ) catch |e| {
                     return switch (e) {
                         else => results.MkdirError.Unexpected,
                     };
@@ -125,7 +137,7 @@ pub fn create(rt: *Runtime, path: fs.Path) !Dir {
             },
         }
 
-        return try Dir.open(rt, path);
+        return try .open(rt, path);
     }
 }
 
@@ -161,7 +173,7 @@ pub fn open_file(
 
 /// Create a Dir relative to this Dir.
 pub fn create_dir(dir: Dir, rt: *Runtime, subpath: [:0]const u8) !Dir {
-    return try Dir.create(rt, .{
+    return try .create(rt, .{
         .rel = .{
             .dir = dir.handle,
             .path = subpath,
@@ -171,7 +183,7 @@ pub fn create_dir(dir: Dir, rt: *Runtime, subpath: [:0]const u8) !Dir {
 
 /// Open a Dir relative to this Dir.
 pub fn open_dir(dir: Dir, rt: *Runtime, subpath: [:0]const u8) !Dir {
-    return try Dir.open(rt, .{
+    return try .open(rt, .{
         .rel = .{
             .dir = dir.handle,
             .path = subpath,
@@ -232,7 +244,10 @@ pub fn delete_file(dir: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
         });
     } else {
         const std_dir = dir.to_std();
-        return std_dir.deleteFile(rt.io, subpath) catch |e| switch (e) {
+        return std_dir.deleteFile(
+            rt.io,
+            subpath,
+        ) catch |e| switch (e) {
             else => results.DeleteError.Unexpected,
         };
     }
@@ -251,7 +266,10 @@ pub fn delete_dir(dir: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
         });
     } else {
         const std_dir = dir.to_std();
-        return std_dir.deleteDir(rt.io, subpath) catch |e| switch (e) {
+        return std_dir.deleteDir(
+            rt.io,
+            subpath,
+        ) catch |e| switch (e) {
             else => results.DeleteError.Unexpected,
         };
     }

--- a/src/fs/dir.zig
+++ b/src/fs/dir.zig
@@ -62,12 +62,12 @@ pub fn open(rt: *Runtime, path: fs.Path) !Dir {
     } else {
         const OpenError = results.OpenError;
         switch (path) {
-            .rel => |inner| {
-                const dir: StdDir = .{ .handle = inner.dir };
+            .rel => |rel| {
+                const dir: StdDir = .{ .handle = rel.dir };
 
                 const opened = dir.openDir(
                     rt.io,
-                    inner.path,
+                    rel.path,
                     .{ .iterate = true },
                 ) catch |e| {
                     return switch (e) {
@@ -78,10 +78,10 @@ pub fn open(rt: *Runtime, path: fs.Path) !Dir {
 
                 return .{ .handle = opened.handle };
             },
-            .abs => |inner| {
+            .abs => |abs| {
                 const opened = Io.Dir.openDirAbsolute(
                     rt.io,
-                    inner,
+                    abs,
                     .{ .iterate = true },
                 ) catch |e| {
                     return switch (e) {

--- a/src/fs/dir.zig
+++ b/src/fs/dir.zig
@@ -20,7 +20,9 @@ pub fn cwd() Dir {
 /// Close the underlying Handle of this Dir.
 pub fn close(self: Dir, rt: *Runtime) !void {
     if (rt.aio.features.has_capability(.close))
-        try rt.scheduler.io_await(.{ .close = self.handle })
+        try rt.scheduler.io_await(rt.allocator, .{
+            .close = self.handle,
+        })
     else
         Io.File.close(.{
             .handle = self.handle,
@@ -41,7 +43,7 @@ pub fn open(rt: *Runtime, path: fs.Path) !Dir {
     };
 
     if (rt.aio.features.has_capability(.open)) {
-        try rt.scheduler.io_await(.{
+        try rt.scheduler.io_await(rt.allocator, .{
             .open = .{
                 .path = path,
                 .flags = flags,
@@ -89,10 +91,12 @@ pub fn open(rt: *Runtime, path: fs.Path) !Dir {
 /// Creates and opens a Directory.
 pub fn create(rt: *Runtime, path: fs.Path) !Dir {
     if (rt.aio.features.has_capability(.mkdir)) {
-        try rt.scheduler.io_await(.{ .mkdir = .{
-            .path = path,
-            .mode = 0o775,
-        } });
+        try rt.scheduler.io_await(rt.allocator, .{
+            .mkdir = .{
+                .path = path,
+                .mode = 0o775,
+            },
+        });
 
         const index = rt.current_task.?;
         const task = rt.scheduler.tasks.get_ptr(index);
@@ -178,7 +182,7 @@ pub fn open_dir(self: Dir, rt: *Runtime, subpath: [:0]const u8) !Dir {
 /// Get Stat information of this Dir.
 pub fn stat(self: Dir, rt: *Runtime) !fs.Stat {
     if (rt.aio.features.has_capability(.stat)) {
-        try rt.scheduler.io_await(.{
+        try rt.scheduler.io_await(rt.allocator, .{
             .stat = self.handle,
         });
 
@@ -217,15 +221,15 @@ pub fn stat(self: Dir, rt: *Runtime) !fs.Stat {
 /// Delete a File within this Dir.
 pub fn delete_file(self: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
     if (rt.aio.features.has_capability(.delete)) {
-        try rt.scheduler.io_await(.{ .delete = .{
-            .path = .{
-                .rel = .{
+        try rt.scheduler.io_await(rt.allocator, .{
+            .delete = .{
+                .path = .{ .rel = .{
                     .dir = self.handle,
                     .path = subpath,
-                },
+                } },
+                .is_dir = false,
             },
-            .is_dir = false,
-        } });
+        });
     } else {
         const std_dir = self.to_std();
         return std_dir.deleteFile(rt.io, subpath) catch |e| switch (e) {
@@ -237,7 +241,7 @@ pub fn delete_file(self: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
 /// Delete a Dir within this Dir.
 pub fn delete_dir(self: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
     if (rt.aio.features.has_capability(.delete)) {
-        try rt.scheduler.io_await(.{
+        try rt.scheduler.io_await(rt.allocator, .{
             .delete = .{ .path = .{
                 .rel = .{
                     .dir = self.handle,

--- a/src/fs/dir.zig
+++ b/src/fs/dir.zig
@@ -3,13 +3,13 @@ pub const Dir = @This();
 handle: std.posix.fd_t,
 
 /// Create a std.fs.Dir from a Dir.
-pub fn to_std(self: Dir) Io.Dir {
-    return .{ .handle = self.handle };
+pub fn to_std(dir: Dir) Io.Dir {
+    return .{ .handle = dir.handle };
 }
 
 /// Create a Dir from the std.fs.Dir
-pub fn from_std(self: Io.Dir) Dir {
-    return .{ .handle = self.handle };
+pub fn from_std(dir: Io.Dir) Dir {
+    return .{ .handle = dir.handle };
 }
 
 /// Get `cwd` as a Dir.
@@ -18,20 +18,20 @@ pub fn cwd() Dir {
 }
 
 /// Close the underlying Handle of this Dir.
-pub fn close(self: Dir, rt: *Runtime) !void {
+pub fn close(dir: Dir, rt: *Runtime) !void {
     if (rt.aio.features.has_capability(.close))
         try rt.scheduler.io_await(rt.allocator, .{
-            .close = self.handle,
+            .close = dir.handle,
         })
     else
         Io.File.close(.{
-            .handle = self.handle,
+            .handle = dir.handle,
             .flags = .{ .nonblocking = true },
         }, rt.io);
 }
 
-pub fn close_blocking(self: Dir) void {
-    syscall.close(self.handle);
+pub fn close_blocking(dir: Dir) void {
+    syscall.close(dir.handle);
 }
 
 /// Open a Directory.
@@ -131,14 +131,14 @@ pub fn create(rt: *Runtime, path: fs.Path) !Dir {
 
 /// Create a File relative to this Dir.
 pub fn create_file(
-    self: Dir,
+    dir: Dir,
     rt: *Runtime,
     subpath: [:0]const u8,
     flags: fs.File.CreateFlags,
 ) !fs.File {
     return try .create(rt, .{
         .rel = .{
-            .dir = self.handle,
+            .dir = dir.handle,
             .path = subpath,
         },
     }, flags);
@@ -146,51 +146,51 @@ pub fn create_file(
 
 /// Open a File relative to this Dir.
 pub fn open_file(
-    self: Dir,
+    dir: Dir,
     rt: *Runtime,
     subpath: [:0]const u8,
     flags: fs.File.OpenFlags,
 ) !fs.File {
     return try .open(rt, .{
         .rel = .{
-            .dir = self.handle,
+            .dir = dir.handle,
             .path = subpath,
         },
     }, flags);
 }
 
 /// Create a Dir relative to this Dir.
-pub fn create_dir(self: Dir, rt: *Runtime, subpath: [:0]const u8) !Dir {
+pub fn create_dir(dir: Dir, rt: *Runtime, subpath: [:0]const u8) !Dir {
     return try Dir.create(rt, .{
         .rel = .{
-            .dir = self.handle,
+            .dir = dir.handle,
             .path = subpath,
         },
     });
 }
 
 /// Open a Dir relative to this Dir.
-pub fn open_dir(self: Dir, rt: *Runtime, subpath: [:0]const u8) !Dir {
+pub fn open_dir(dir: Dir, rt: *Runtime, subpath: [:0]const u8) !Dir {
     return try Dir.open(rt, .{
         .rel = .{
-            .dir = self.handle,
+            .dir = dir.handle,
             .path = subpath,
         },
     });
 }
 
 /// Get Stat information of this Dir.
-pub fn stat(self: Dir, rt: *Runtime) !fs.Stat {
+pub fn stat(dir: Dir, rt: *Runtime) !fs.Stat {
     if (rt.aio.features.has_capability(.stat)) {
         try rt.scheduler.io_await(rt.allocator, .{
-            .stat = self.handle,
+            .stat = dir.handle,
         });
 
         const index = rt.current_task.?;
         const task = rt.scheduler.tasks.get_ptr(index);
         return try task.result.stat.unwrap();
     } else {
-        const std_dir = self.to_std();
+        const std_dir = dir.to_std();
         const dir_stat = std_dir.stat() catch |e| {
             return switch (e) {
                 error.AccessDenied => results.StatError.AccessDenied,
@@ -219,19 +219,19 @@ pub fn stat(self: Dir, rt: *Runtime) !fs.Stat {
 }
 
 /// Delete a File within this Dir.
-pub fn delete_file(self: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
+pub fn delete_file(dir: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
     if (rt.aio.features.has_capability(.delete)) {
         try rt.scheduler.io_await(rt.allocator, .{
             .delete = .{
                 .path = .{ .rel = .{
-                    .dir = self.handle,
+                    .dir = dir.handle,
                     .path = subpath,
                 } },
                 .is_dir = false,
             },
         });
     } else {
-        const std_dir = self.to_std();
+        const std_dir = dir.to_std();
         return std_dir.deleteFile(rt.io, subpath) catch |e| switch (e) {
             else => results.DeleteError.Unexpected,
         };
@@ -239,18 +239,18 @@ pub fn delete_file(self: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
 }
 
 /// Delete a Dir within this Dir.
-pub fn delete_dir(self: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
+pub fn delete_dir(dir: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
     if (rt.aio.features.has_capability(.delete)) {
         try rt.scheduler.io_await(rt.allocator, .{
             .delete = .{ .path = .{
                 .rel = .{
-                    .dir = self.handle,
+                    .dir = dir.handle,
                     .path = subpath,
                 },
             }, .is_dir = true },
         });
     } else {
-        const std_dir = self.to_std();
+        const std_dir = dir.to_std();
         return std_dir.deleteDir(rt.io, subpath) catch |e| switch (e) {
             else => results.DeleteError.Unexpected,
         };
@@ -261,8 +261,8 @@ pub fn delete_dir(self: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
 /// deleting all files within it and then deleting the Directory.
 ///
 /// This does allocate within it using the `rt.allocator`.
-pub fn delete_tree(self: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
-    const base_dir = try self.open_dir(rt, subpath);
+pub fn delete_tree(dir: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
+    const base_dir = try dir.open_dir(rt, subpath);
 
     const base_std_dir = base_dir.to_std();
     var walker = try base_std_dir.walk(rt.allocator);
@@ -277,7 +277,7 @@ pub fn delete_tree(self: Dir, rt: *Runtime, subpath: [:0]const u8) !void {
     }
 
     try base_dir.close(rt);
-    try self.delete_dir(rt, subpath);
+    try dir.delete_dir(rt, subpath);
 }
 
 const log = std.log.scoped(.@"tardy/fs/dir");

--- a/src/fs/file.zig
+++ b/src/fs/file.zig
@@ -202,7 +202,11 @@ pub fn open(rt: *Runtime, path: fs.Path, flags: OpenFlags) !File {
 
                 const OpenError = results.OpenError;
                 const opened: StdFile = blk: while (true) {
-                    break :blk dir.openFile(rt.io, inner.path, std_flags) catch |e| return switch (e) {
+                    break :blk dir.openFile(
+                        rt.io,
+                        inner.path,
+                        std_flags,
+                    ) catch |e| return switch (e) {
                         error.WouldBlock => {
                             Coroutine.yield();
                             continue;
@@ -233,7 +237,11 @@ pub fn open(rt: *Runtime, path: fs.Path, flags: OpenFlags) !File {
             .abs => |inner| {
                 const OpenError = results.OpenError;
                 const opened: StdFile = blk: while (true) {
-                    break :blk Io.Dir.openFileAbsolute(rt.io, inner, std_flags) catch |e| return switch (e) {
+                    break :blk Io.Dir.openFileAbsolute(
+                        rt.io,
+                        inner,
+                        std_flags,
+                    ) catch |e| return switch (e) {
                         error.WouldBlock => {
                             Coroutine.yield();
                             continue;
@@ -333,7 +341,11 @@ pub fn read_all(file: File, rt: *Runtime, buffer: []u8, offset: ?usize) !usize {
     while (length < buffer.len) {
         const real_offset: ?usize = if (offset) |o| o + length else null;
 
-        const result = file.read(rt, buffer[length..], real_offset) catch |e| switch (e) {
+        const result = file.read(
+            rt,
+            buffer[length..],
+            real_offset,
+        ) catch |e| switch (e) {
             error.EndOfFile => return length,
             else => |err| return err,
         };
@@ -370,7 +382,11 @@ pub fn write(
         // TODO: Proper and improved error handling (also why not error.*)
         if (offset) |o| {
             return blk: while (true) {
-                break :blk std_file.writePositional(rt.io, &.{buffer}, o) catch |e| switch (e) {
+                break :blk std_file.writePositional(
+                    rt.io,
+                    &.{buffer},
+                    o,
+                ) catch |e| switch (e) {
                     error.WouldBlock => {
                         Coroutine.yield();
                         continue;
@@ -388,7 +404,12 @@ pub fn write(
             };
         } else {
             return blk: while (true) {
-                break :blk std_file.writeStreaming(rt.io, &.{}, &.{buffer}, 0) catch |e| switch (e) {
+                break :blk std_file.writeStreaming(
+                    rt.io,
+                    &.{},
+                    &.{buffer},
+                    0,
+                ) catch |e| switch (e) {
                     error.WouldBlock => {
                         Coroutine.yield();
                         continue;
@@ -446,7 +467,7 @@ pub fn stat(file: File, rt: *Runtime) !fs.Stat {
         const std_file = file.to_std();
 
         const StatError = results.StatError;
-        const file_stat = std_file.stat(rt.io) catch |e| {
+        const file_stat = std_file.stat(rt.io) catch |e|
             return switch (e) {
                 error.AccessDenied => StatError.AccessDenied,
                 error.SystemResources => StatError.OutOfMemory,
@@ -454,7 +475,6 @@ pub fn stat(file: File, rt: *Runtime) !fs.Stat {
                 error.PermissionDenied => StatError.PermissionDenied,
                 error.Streaming, error.Canceled => unreachable,
             };
-        };
 
         return .{
             .size = file_stat.size,
@@ -472,7 +492,11 @@ pub fn stream_to(from: File, to_w: *Io.Writer, rt: *Runtime) !void {
     var file = from.reader(rt, &.{});
     const file_r = &file.interface;
     while (true) {
-        _ = Reader.stream(file_r, to_w, .limited(to_w.buffer.len)) catch |e| switch (e) {
+        _ = Reader.stream(
+            file_r,
+            to_w,
+            .limited(to_w.buffer.len),
+        ) catch |e| switch (e) {
             error.EndOfStream => break,
             else => |err| return err,
         };
@@ -506,28 +530,46 @@ pub const Writer = struct {
     }
 
     pub fn drain(io_w: *Io.Writer, data: []const []const u8, splat: usize) Io.Writer.Error!usize {
-        const w: *Writer = @alignCast(@fieldParentPtr("interface", io_w));
+        const w: *Writer = @alignCast(@fieldParentPtr(
+            "interface",
+            io_w,
+        ));
+
         const buffered = io_w.buffered();
         if (buffered.len != 0) {
-            const n = w.file.write(w.rt, buffered, w.pos) catch |err| {
+            const n = w.file.write(
+                w.rt,
+                buffered,
+                w.pos,
+            ) catch |err| {
                 w.err = err;
                 return error.WriteFailed;
             };
             w.pos += n;
             return io_w.consume(n);
         }
+
         for (data[0 .. data.len - 1]) |buf| {
             if (buf.len == 0) continue;
-            const n = w.file.write(w.rt, buf, w.pos) catch |err| {
+            const n = w.file.write(
+                w.rt,
+                buf,
+                w.pos,
+            ) catch |err| {
                 w.err = err;
                 return error.WriteFailed;
             };
             w.pos += n;
             return io_w.consume(n);
         }
+
         const pattern = data[data.len - 1];
         if (pattern.len == 0 or splat == 0) return 0;
-        const n = w.file.write(w.rt, pattern, w.pos) catch |err| {
+        const n = w.file.write(
+            w.rt,
+            pattern,
+            w.pos,
+        ) catch |err| {
             w.err = err;
             return error.WriteFailed;
         };
@@ -575,19 +617,23 @@ pub const Reader = struct {
     }
 
     pub fn stream(io_reader: *Io.Reader, w: *Io.Writer, limit: Io.Limit) Io.Reader.StreamError!usize {
-        const r: *Reader = @alignCast(@fieldParentPtr("interface", io_reader));
+        const r: *Reader = @alignCast(@fieldParentPtr(
+            "interface",
+            io_reader,
+        ));
         const w_dest = limit.slice(try w.writableSliceGreedy(1));
 
-        const n = r.file.read(r.rt, w_dest, r.pos) catch |err| switch (err) {
-            error.EndOfFile => {
-                r.size = r.pos;
-                return error.EndOfStream;
-            },
-            else => {
-                r.err = err;
-                return error.ReadFailed;
-            },
-        };
+        const n = r.file.read(r.rt, w_dest, r.pos) catch |err|
+            switch (err) {
+                error.EndOfFile => {
+                    r.size = r.pos;
+                    return error.EndOfStream;
+                },
+                else => {
+                    r.err = err;
+                    return error.ReadFailed;
+                },
+            };
         r.pos += n;
         w.advance(n);
         return n;

--- a/src/fs/file.zig
+++ b/src/fs/file.zig
@@ -92,14 +92,14 @@ pub fn create(rt: *Runtime, path: fs.Path, flags: CreateFlags) !File {
         };
 
         switch (path) {
-            .rel => |inner| {
-                const dir: StdDir = .{ .handle = inner.dir };
+            .rel => |rel| {
+                const dir: StdDir = .{ .handle = rel.dir };
 
                 const OpenError = results.OpenError;
                 const opened: StdFile = blk: while (true) {
                     break :blk dir.createFile(
                         rt.io,
-                        inner.path,
+                        rel.path,
                         std_flags,
                     ) catch |e| return switch (e) {
                         error.WouldBlock => {
@@ -129,12 +129,12 @@ pub fn create(rt: *Runtime, path: fs.Path, flags: CreateFlags) !File {
 
                 return .{ .handle = opened.handle };
             },
-            .abs => |inner| {
+            .abs => |abs| {
                 const OpenError = results.OpenError;
                 const opened: StdFile = blk: while (true) {
                     break :blk Io.Dir.createFileAbsolute(
                         rt.io,
-                        inner,
+                        abs,
                         std_flags,
                     ) catch |e| return switch (e) {
                         error.WouldBlock => {
@@ -197,14 +197,14 @@ pub fn open(rt: *Runtime, path: fs.Path, flags: OpenFlags) !File {
         };
 
         switch (path) {
-            .rel => |inner| {
-                const dir: StdDir = .{ .handle = inner.dir };
+            .rel => |rel| {
+                const dir: StdDir = .{ .handle = rel.dir };
 
                 const OpenError = results.OpenError;
                 const opened: StdFile = blk: while (true) {
                     break :blk dir.openFile(
                         rt.io,
-                        inner.path,
+                        rel.path,
                         std_flags,
                     ) catch |e| return switch (e) {
                         error.WouldBlock => {
@@ -234,12 +234,12 @@ pub fn open(rt: *Runtime, path: fs.Path, flags: OpenFlags) !File {
 
                 return .{ .handle = opened.handle };
             },
-            .abs => |inner| {
+            .abs => |abs| {
                 const OpenError = results.OpenError;
                 const opened: StdFile = blk: while (true) {
                     break :blk Io.Dir.openFileAbsolute(
                         rt.io,
-                        inner,
+                        abs,
                         std_flags,
                     ) catch |e| return switch (e) {
                         error.WouldBlock => {

--- a/src/fs/file.zig
+++ b/src/fs/file.zig
@@ -49,7 +49,9 @@ pub fn std_err() File {
 
 pub fn close(self: File, rt: *Runtime) !void {
     if (rt.aio.features.has_capability(.close))
-        try rt.scheduler.io_await(.{ .close = self.handle })
+        try rt.scheduler.io_await(rt.allocator, .{
+            .close = self.handle,
+        })
     else
         syscall.close(self.handle);
 }
@@ -69,7 +71,9 @@ pub fn create(rt: *Runtime, path: fs.Path, flags: CreateFlags) !File {
     };
 
     if (rt.aio.features.has_capability(.open)) {
-        try rt.scheduler.io_await(.{ .open = .{ .path = path, .flags = aio_flags } });
+        try rt.scheduler.io_await(rt.allocator, .{
+            .open = .{ .path = path, .flags = aio_flags },
+        });
 
         const index = rt.current_task.?;
         const task = rt.scheduler.tasks.get(index);
@@ -171,7 +175,9 @@ pub fn open(rt: *Runtime, path: fs.Path, flags: OpenFlags) !File {
             .directory = false,
         };
 
-        try rt.scheduler.io_await(.{ .open = .{ .path = path, .flags = aio_flags } });
+        try rt.scheduler.io_await(rt.allocator, .{
+            .open = .{ .path = path, .flags = aio_flags },
+        });
 
         const index = rt.current_task.?;
         const task = rt.scheduler.tasks.get(index);
@@ -260,7 +266,7 @@ pub fn open(rt: *Runtime, path: fs.Path, flags: OpenFlags) !File {
 
 pub fn read(self: File, rt: *Runtime, buffer: []u8, offset: ?usize) !usize {
     if (rt.aio.features.has_capability(.read)) {
-        try rt.scheduler.io_await(.{
+        try rt.scheduler.io_await(rt.allocator, .{
             .read = .{
                 .fd = self.handle,
                 .buffer = buffer,
@@ -345,8 +351,12 @@ pub fn write(
     offset: ?usize,
 ) results.WriteError!usize {
     if (rt.aio.features.has_capability(.write)) {
-        rt.scheduler.io_await(.{
-            .write = .{ .fd = self.handle, .buffer = buffer, .offset = offset },
+        rt.scheduler.io_await(rt.allocator, .{
+            .write = .{
+                .fd = self.handle,
+                .buffer = buffer,
+                .offset = offset,
+            },
         }) catch unreachable;
 
         const index = rt.current_task.?;
@@ -425,7 +435,9 @@ pub fn write_all(
 
 pub fn stat(self: File, rt: *Runtime) !fs.Stat {
     if (rt.aio.features.has_capability(.stat)) {
-        try rt.scheduler.io_await(.{ .stat = self.handle });
+        try rt.scheduler.io_await(rt.allocator, .{
+            .stat = self.handle,
+        });
 
         const index = rt.current_task.?;
         const task = rt.scheduler.tasks.get(index);

--- a/src/fs/file.zig
+++ b/src/fs/file.zig
@@ -21,15 +21,15 @@ pub const OpenFlags = struct {
     mode: AsyncIO.FileMode = .read,
 };
 
-pub fn to_std(self: File) Io.File {
+pub fn to_std(file: File) Io.File {
     return .{
-        .handle = self.handle,
+        .handle = file.handle,
         .flags = .{ .nonblocking = false },
     };
 }
 
-pub fn from_std(self: Io.File) File {
-    return .{ .handle = self.handle };
+pub fn from_std(file: Io.File) File {
+    return .{ .handle = file.handle };
 }
 
 /// Get `stdout` as a File.
@@ -47,17 +47,17 @@ pub fn std_err() File {
     return .{ .handle = cross.get_std_err() };
 }
 
-pub fn close(self: File, rt: *Runtime) !void {
+pub fn close(file: File, rt: *Runtime) !void {
     if (rt.aio.features.has_capability(.close))
         try rt.scheduler.io_await(rt.allocator, .{
-            .close = self.handle,
+            .close = file.handle,
         })
     else
-        syscall.close(self.handle);
+        syscall.close(file.handle);
 }
 
-pub fn close_blocking(self: File) void {
-    syscall.close(self.handle);
+pub fn close_blocking(file: File) void {
+    syscall.close(file.handle);
 }
 
 pub fn create(rt: *Runtime, path: fs.Path, flags: CreateFlags) !File {
@@ -264,11 +264,11 @@ pub fn open(rt: *Runtime, path: fs.Path, flags: OpenFlags) !File {
     }
 }
 
-pub fn read(self: File, rt: *Runtime, buffer: []u8, offset: ?usize) !usize {
+pub fn read(file: File, rt: *Runtime, buffer: []u8, offset: ?usize) !usize {
     if (rt.aio.features.has_capability(.read)) {
         try rt.scheduler.io_await(rt.allocator, .{
             .read = .{
-                .fd = self.handle,
+                .fd = file.handle,
                 .buffer = buffer,
                 .offset = offset,
             },
@@ -278,7 +278,7 @@ pub fn read(self: File, rt: *Runtime, buffer: []u8, offset: ?usize) !usize {
         const task = rt.scheduler.tasks.get(index);
         return try task.result.read.unwrap();
     } else {
-        const std_file = self.to_std();
+        const std_file = file.to_std();
 
         const ReadError = results.ReadError;
         const count = blk: {
@@ -324,16 +324,16 @@ pub fn read(self: File, rt: *Runtime, buffer: []u8, offset: ?usize) !usize {
         if (count == 0) return ReadError.EndOfFile;
         return count;
     }
-    return .{ .file = self, .buffer = buffer, .offset = offset };
+    return .{ .file = file, .buffer = buffer, .offset = offset };
 }
 
-pub fn read_all(self: File, rt: *Runtime, buffer: []u8, offset: ?usize) !usize {
+pub fn read_all(file: File, rt: *Runtime, buffer: []u8, offset: ?usize) !usize {
     var length: usize = 0;
 
     while (length < buffer.len) {
         const real_offset: ?usize = if (offset) |o| o + length else null;
 
-        const result = self.read(rt, buffer[length..], real_offset) catch |e| switch (e) {
+        const result = file.read(rt, buffer[length..], real_offset) catch |e| switch (e) {
             error.EndOfFile => return length,
             else => |err| return err,
         };
@@ -345,7 +345,7 @@ pub fn read_all(self: File, rt: *Runtime, buffer: []u8, offset: ?usize) !usize {
 }
 
 pub fn write(
-    self: File,
+    file: File,
     rt: *Runtime,
     buffer: []const u8,
     offset: ?usize,
@@ -353,7 +353,7 @@ pub fn write(
     if (rt.aio.features.has_capability(.write)) {
         rt.scheduler.io_await(rt.allocator, .{
             .write = .{
-                .fd = self.handle,
+                .fd = file.handle,
                 .buffer = buffer,
                 .offset = offset,
             },
@@ -363,7 +363,7 @@ pub fn write(
         const task = rt.scheduler.tasks.get(index);
         return try task.result.write.unwrap();
     } else {
-        const std_file = self.to_std();
+        const std_file = file.to_std();
 
         const WriteError = results.WriteError;
         // TODO: fix `error.Unseekable` when fd is a fifo
@@ -408,7 +408,7 @@ pub fn write(
 }
 
 pub fn write_all(
-    self: File,
+    file: File,
     rt: *Runtime,
     buffer: []const u8,
     offset: ?usize,
@@ -418,7 +418,7 @@ pub fn write_all(
     while (length < buffer.len) {
         const real_offset: ?usize = if (offset) |o| o + length else null;
 
-        const result = self.write(
+        const result = file.write(
             rt,
             buffer[length..],
             real_offset,
@@ -433,17 +433,17 @@ pub fn write_all(
     return length;
 }
 
-pub fn stat(self: File, rt: *Runtime) !fs.Stat {
+pub fn stat(file: File, rt: *Runtime) !fs.Stat {
     if (rt.aio.features.has_capability(.stat)) {
         try rt.scheduler.io_await(rt.allocator, .{
-            .stat = self.handle,
+            .stat = file.handle,
         });
 
         const index = rt.current_task.?;
         const task = rt.scheduler.tasks.get(index);
         return try task.result.stat.unwrap();
     } else {
-        const std_file = self.to_std();
+        const std_file = file.to_std();
 
         const StatError = results.StatError;
         const file_stat = std_file.stat(rt.io) catch |e| {

--- a/src/net/Socket.zig
+++ b/src/net/Socket.zig
@@ -149,7 +149,9 @@ pub const Address = union(enum) {
     pub fn fromAny(addr: *const posix.sockaddr) Address {
         switch (addr.family) {
             posix.AF.INET => {
-                const sock = @as(*const posix.sockaddr.in, @ptrCast(@alignCast(addr))).*;
+                const sock = @as(*const posix.sockaddr.in, @ptrCast(@alignCast(
+                    addr,
+                ))).*;
                 return .{
                     .ip = .{
                         .ip4 = .{
@@ -160,7 +162,9 @@ pub const Address = union(enum) {
                 };
             },
             posix.AF.INET6 => {
-                const sock6 = @as(*const posix.sockaddr.in6, @ptrCast(@alignCast(addr))).*;
+                const sock6 = @as(*const posix.sockaddr.in6, @ptrCast(@alignCast(
+                    addr,
+                ))).*;
                 return .{
                     .ip = .{
                         .ip6 = .{
@@ -173,7 +177,9 @@ pub const Address = union(enum) {
                 };
             },
             posix.AF.UNIX => {
-                const sockun = @as(*const posix.sockaddr.un, @ptrCast(@alignCast(addr))).*;
+                const sockun = @as(*const posix.sockaddr.un, @ptrCast(@alignCast(
+                    addr,
+                ))).*;
                 return .{
                     .unix = .{
                         .path = mem.sliceTo(&sockun.path, 0x0),
@@ -193,7 +199,10 @@ pub const Address = union(enum) {
                             .addr = @bitCast(ip4.bytes),
                             .port = mem.nativeToBig(u16, ip4.port),
                         };
-                        const addr_: posix.sockaddr = @as(*const posix.sockaddr, @ptrCast(@alignCast(&saddr))).*;
+                        const addr_: posix.sockaddr = @as(
+                            *const posix.sockaddr,
+                            @ptrCast(@alignCast(&saddr)),
+                        ).*;
                         return .{ addr_, @sizeOf(@TypeOf(saddr)) };
                     },
                     .ip6 => |ip6| {
@@ -203,7 +212,10 @@ pub const Address = union(enum) {
                             .scope_id = ip6.interface.index,
                             .port = mem.nativeToBig(u16, ip6.port),
                         };
-                        const addr_: posix.sockaddr = @as(*const posix.sockaddr, @ptrCast(@alignCast(&saddr))).*;
+                        const addr_: posix.sockaddr = @as(
+                            *const posix.sockaddr,
+                            @ptrCast(@alignCast(&saddr)),
+                        ).*;
                         return .{ addr_, @sizeOf(@TypeOf(saddr)) };
                     },
                 }
@@ -213,7 +225,10 @@ pub const Address = union(enum) {
                     .path = @splat(0x0),
                 };
                 @memcpy(saddr.path[0..unix.path.len], unix.path[0..]);
-                const addr_: posix.sockaddr = @as(*const posix.sockaddr, @ptrCast(@alignCast(&saddr))).*;
+                const addr_: posix.sockaddr = @as(
+                    *const posix.sockaddr,
+                    @ptrCast(@alignCast(&saddr)),
+                ).*;
                 return .{ addr_, @sizeOf(@TypeOf(saddr)) };
             },
         }
@@ -224,13 +239,19 @@ pub const Address = union(enum) {
 pub fn init(io_: Io, kind: InitKind) !Socket {
     const addr: Address = switch (kind) {
         .tcp, .udp => |inner| blk: {
-            break :blk if (comptime builtin.os.tag == .linux)
-                .{ .ip = try .resolve(io_, inner.host, inner.port) }
-            else
-                .{ .ip = try .parse(inner.host, inner.port) };
+            break :blk if (comptime builtin.os.tag == .linux) .{
+                .ip = try .resolve(
+                    io_,
+                    inner.host,
+                    inner.port,
+                ),
+            } else .{ .ip = try .parse(inner.host, inner.port) };
         },
         // Not supported on Windows at the moment.
-        .unix => |path| if (builtin.os.tag == .windows) unreachable else .{ .unix = try .init(path) },
+        .unix => |path| if (builtin.os.tag == .windows)
+            unreachable
+        else
+            .{ .unix = try .init(path) },
     };
 
     return try init_with_address(kind, addr);
@@ -261,7 +282,11 @@ pub fn init_with_address(kind: Kind, addr: Address) !Socket {
         sock_type;
 
     // TODO: audit these and posix uses across tardy
-    const socket = try syscall.socket(family, flags, protocol);
+    const socket = try syscall.socket(
+        family,
+        flags,
+        protocol,
+    );
 
     if (kind != .unix) {
         if (@hasDecl(posix.SO, "REUSEPORT_LB")) {
@@ -423,10 +448,11 @@ pub fn recv_all(sock: Socket, rt: *Runtime, buffer: []u8) !usize {
     var length: usize = 0;
 
     while (length < buffer.len) {
-        const result = sock.recv(rt, buffer[length..]) catch |e| switch (e) {
-            error.Closed => return length,
-            else => |err| return err,
-        };
+        const result = sock.recv(rt, buffer[length..]) catch |e|
+            switch (e) {
+                error.Closed => return length,
+                else => |err| return err,
+            };
 
         length += result;
     }
@@ -510,8 +536,14 @@ pub const Writer = struct {
         };
     }
 
-    pub fn drain(io_w: *Io.Writer, data: []const []const u8, splat: usize) Io.Writer.Error!usize {
-        const w: *Writer = @alignCast(@fieldParentPtr("interface", io_w));
+    pub fn drain(
+        io_w: *Io.Writer,
+        data: []const []const u8,
+        splat: usize,
+    ) Io.Writer.Error!usize {
+        const w: *Writer = @alignCast(
+            @fieldParentPtr("interface", io_w),
+        );
         const buffered = io_w.buffered();
 
         if (buffered.len != 0) {
@@ -522,6 +554,7 @@ pub const Writer = struct {
             w.pos += n;
             return io_w.consume(n);
         }
+
         for (data[0 .. data.len - 1]) |buf| {
             if (buf.len == 0) continue;
             const n = w.socket.send(w.rt, buf) catch |err| {
@@ -531,6 +564,7 @@ pub const Writer = struct {
             w.pos += n;
             return io_w.consume(n);
         }
+
         const pattern = data[data.len - 1];
         if (pattern.len == 0 or splat == 0) return 0;
         const n = w.socket.send(w.rt, pattern) catch |err| {
@@ -579,19 +613,27 @@ pub const Reader = struct {
         };
     }
 
-    fn stream(io_reader: *Io.Reader, w: *Io.Writer, limit: Io.Limit) Io.Reader.StreamError!usize {
-        const r: *Reader = @alignCast(@fieldParentPtr("interface", io_reader));
+    fn stream(
+        io_reader: *Io.Reader,
+        w: *Io.Writer,
+        limit: Io.Limit,
+    ) Io.Reader.StreamError!usize {
+        const r: *Reader = @alignCast(
+            @fieldParentPtr("interface", io_reader),
+        );
         const w_dest = limit.slice(try w.writableSliceGreedy(1));
 
-        const n = r.socket.recv(r.rt, w_dest) catch |err| switch (err) {
-            error.Closed => {
-                return error.EndOfStream;
-            },
-            else => {
-                r.err = err;
-                return error.ReadFailed;
-            },
-        };
+        const n = r.socket.recv(r.rt, w_dest) catch |err|
+            switch (err) {
+                error.Closed => {
+                    return error.EndOfStream;
+                },
+                else => {
+                    r.err = err;
+                    return error.ReadFailed;
+                },
+            };
+
         r.pos += n;
         w.advance(n);
         return n;
@@ -613,7 +655,11 @@ pub fn stream_to(from: Socket, to_w: *Io.Writer, rt: *Runtime) !void {
     var file = from.reader(rt, &.{});
     const file_r = &file.interface;
     while (true) {
-        _ = Reader.stream(file_r, to_w, .limited(to_w.buffer.len)) catch |e| switch (e) {
+        _ = Reader.stream(
+            file_r,
+            to_w,
+            .limited(to_w.buffer.len),
+        ) catch |e| switch (e) {
             error.EndOfStream => break,
             else => |err| return err,
         };

--- a/src/net/Socket.zig
+++ b/src/net/Socket.zig
@@ -305,7 +305,9 @@ pub fn listen(self: Socket, backlog: usize) !void {
 // TODO: rethink the aio to io approach
 pub fn close(self: Socket, rt: *Runtime) !void {
     if (rt.aio.features.has_capability(.close))
-        try rt.scheduler.io_await(.{ .close = self.handle })
+        try rt.scheduler.io_await(rt.allocator, .{
+            .close = self.handle,
+        })
     else
         syscall.close(self.handle);
 }
@@ -319,7 +321,7 @@ pub fn close_blocking(self: Socket) void {
 pub fn accept(self: Socket, rt: *Runtime) !Socket {
     debug.assert(self.kind.listenable());
     if (rt.aio.features.has_capability(.accept)) {
-        try rt.scheduler.io_await(.{
+        try rt.scheduler.io_await(rt.allocator, .{
             .accept = .{
                 .socket = self.handle,
                 .kind = self.kind,
@@ -362,7 +364,7 @@ pub fn accept(self: Socket, rt: *Runtime) !Socket {
 
 pub fn connect(self: Socket, rt: *Runtime) !void {
     if (rt.aio.features.has_capability(.connect)) {
-        try rt.scheduler.io_await(.{
+        try rt.scheduler.io_await(rt.allocator, .{
             .connect = .{
                 .socket = self.handle,
                 .addr = self.addr,
@@ -391,7 +393,7 @@ pub fn connect(self: Socket, rt: *Runtime) !void {
 
 pub fn recv(self: Socket, rt: *Runtime, buffer: []u8) !usize {
     if (rt.aio.features.has_capability(.recv)) {
-        try rt.scheduler.io_await(.{
+        try rt.scheduler.io_await(rt.allocator, .{
             .recv = .{
                 .socket = self.handle,
                 .buffer = buffer,
@@ -434,7 +436,7 @@ pub fn recv_all(self: Socket, rt: *Runtime, buffer: []u8) !usize {
 
 pub fn send(self: Socket, rt: *Runtime, buffer: []const u8) !usize {
     if (rt.aio.features.has_capability(.send)) {
-        try rt.scheduler.io_await(.{
+        try rt.scheduler.io_await(rt.allocator, .{
             .send = .{
                 .socket = self.handle,
                 .buffer = buffer,

--- a/src/net/Socket.zig
+++ b/src/net/Socket.zig
@@ -238,14 +238,14 @@ pub const Address = union(enum) {
 // TODO: we shouldn't need Io here
 pub fn init(io_: Io, kind: InitKind) !Socket {
     const addr: Address = switch (kind) {
-        .tcp, .udp => |inner| blk: {
+        .tcp, .udp => |hostname| blk: {
             break :blk if (comptime builtin.os.tag == .linux) .{
                 .ip = try .resolve(
                     io_,
-                    inner.host,
-                    inner.port,
+                    hostname.host,
+                    hostname.port,
                 ),
-            } else .{ .ip = try .parse(inner.host, inner.port) };
+            } else .{ .ip = try .parse(hostname.host, hostname.port) };
         },
         // Not supported on Windows at the moment.
         .unix => |path| if (builtin.os.tag == .windows)

--- a/src/net/Socket.zig
+++ b/src/net/Socket.zig
@@ -10,8 +10,8 @@ pub const Kind = enum {
     udp,
     unix,
 
-    pub fn listenable(self: Kind) bool {
-        return switch (self) {
+    pub fn listenable(kind: Kind) bool {
+        return switch (kind) {
             .tcp, .unix => true,
             else => false,
         };
@@ -297,34 +297,34 @@ pub fn bind(sock: Socket) !void {
 }
 
 /// Listen on the Current Socket.
-pub fn listen(self: Socket, backlog: usize) !void {
-    debug.assert(self.kind.listenable());
-    try syscall.listen(self.handle, @truncate(backlog));
+pub fn listen(sock: Socket, backlog: usize) !void {
+    debug.assert(sock.kind.listenable());
+    try syscall.listen(sock.handle, @truncate(backlog));
 }
 
 // TODO: rethink the aio to io approach
-pub fn close(self: Socket, rt: *Runtime) !void {
+pub fn close(sock: Socket, rt: *Runtime) !void {
     if (rt.aio.features.has_capability(.close))
         try rt.scheduler.io_await(rt.allocator, .{
-            .close = self.handle,
+            .close = sock.handle,
         })
     else
-        syscall.close(self.handle);
+        syscall.close(sock.handle);
 }
 
-pub fn close_blocking(self: Socket) void {
+pub fn close_blocking(sock: Socket) void {
     // todo: delete the unix socket if the
     // server is being closed
-    syscall.close(self.handle);
+    syscall.close(sock.handle);
 }
 
-pub fn accept(self: Socket, rt: *Runtime) !Socket {
-    debug.assert(self.kind.listenable());
+pub fn accept(sock: Socket, rt: *Runtime) !Socket {
+    debug.assert(sock.kind.listenable());
     if (rt.aio.features.has_capability(.accept)) {
         try rt.scheduler.io_await(rt.allocator, .{
             .accept = .{
-                .socket = self.handle,
-                .kind = self.kind,
+                .socket = sock.handle,
+                .kind = sock.kind,
             },
         });
 
@@ -337,7 +337,7 @@ pub fn accept(self: Socket, rt: *Runtime) !Socket {
         const AcceptError = results.AcceptError;
         const socket: posix.socket_t = blk: while (true) {
             break :blk syscall.accept(
-                self.handle,
+                sock.handle,
                 &addr,
                 if (builtin.os.tag != .windows) posix.SOCK.NONBLOCK else 0,
             ) catch |e| return switch (e) {
@@ -357,18 +357,18 @@ pub fn accept(self: Socket, rt: *Runtime) !Socket {
         return .{
             .handle = socket,
             .addr = addr,
-            .kind = self.kind,
+            .kind = sock.kind,
         };
     }
 }
 
-pub fn connect(self: Socket, rt: *Runtime) !void {
+pub fn connect(sock: Socket, rt: *Runtime) !void {
     if (rt.aio.features.has_capability(.connect)) {
         try rt.scheduler.io_await(rt.allocator, .{
             .connect = .{
-                .socket = self.handle,
-                .addr = self.addr,
-                .kind = self.kind,
+                .socket = sock.handle,
+                .addr = sock.addr,
+                .kind = sock.kind,
             },
         });
 
@@ -378,8 +378,8 @@ pub fn connect(self: Socket, rt: *Runtime) !void {
     } else {
         while (true) {
             break syscall.connect(
-                self.handle,
-                &self.addr,
+                sock.handle,
+                &sock.addr,
             ) catch |e| return switch (e) {
                 error.WouldBlock => {
                     Coroutine.yield();
@@ -391,11 +391,11 @@ pub fn connect(self: Socket, rt: *Runtime) !void {
     }
 }
 
-pub fn recv(self: Socket, rt: *Runtime, buffer: []u8) !usize {
+pub fn recv(sock: Socket, rt: *Runtime, buffer: []u8) !usize {
     if (rt.aio.features.has_capability(.recv)) {
         try rt.scheduler.io_await(rt.allocator, .{
             .recv = .{
-                .socket = self.handle,
+                .socket = sock.handle,
                 .buffer = buffer,
             },
         });
@@ -405,7 +405,7 @@ pub fn recv(self: Socket, rt: *Runtime, buffer: []u8) !usize {
         return try task.result.recv.unwrap();
     } else {
         const count: usize = blk: while (true) {
-            break :blk syscall.recv(self.handle, buffer, 0) catch |e| return switch (e) {
+            break :blk syscall.recv(sock.handle, buffer, 0) catch |e| return switch (e) {
                 error.WouldBlock => {
                     Coroutine.yield();
                     continue;
@@ -419,11 +419,11 @@ pub fn recv(self: Socket, rt: *Runtime, buffer: []u8) !usize {
     }
 }
 
-pub fn recv_all(self: Socket, rt: *Runtime, buffer: []u8) !usize {
+pub fn recv_all(sock: Socket, rt: *Runtime, buffer: []u8) !usize {
     var length: usize = 0;
 
     while (length < buffer.len) {
-        const result = self.recv(rt, buffer[length..]) catch |e| switch (e) {
+        const result = sock.recv(rt, buffer[length..]) catch |e| switch (e) {
             error.Closed => return length,
             else => |err| return err,
         };
@@ -434,11 +434,11 @@ pub fn recv_all(self: Socket, rt: *Runtime, buffer: []u8) !usize {
     return length;
 }
 
-pub fn send(self: Socket, rt: *Runtime, buffer: []const u8) !usize {
+pub fn send(sock: Socket, rt: *Runtime, buffer: []const u8) !usize {
     if (rt.aio.features.has_capability(.send)) {
         try rt.scheduler.io_await(rt.allocator, .{
             .send = .{
-                .socket = self.handle,
+                .socket = sock.handle,
                 .buffer = buffer,
             },
         });
@@ -449,7 +449,7 @@ pub fn send(self: Socket, rt: *Runtime, buffer: []const u8) !usize {
     } else {
         const count: usize = blk: while (true) {
             break :blk syscall.send(
-                self.handle,
+                sock.handle,
                 buffer,
                 0,
             ) catch |e| return switch (e) {
@@ -468,11 +468,11 @@ pub fn send(self: Socket, rt: *Runtime, buffer: []const u8) !usize {
     }
 }
 
-pub fn send_all(self: Socket, rt: *Runtime, buffer: []const u8) !usize {
+pub fn send_all(sock: Socket, rt: *Runtime, buffer: []const u8) !usize {
     var length: usize = 0;
 
     while (length < buffer.len) {
-        const result = self.send(
+        const result = sock.send(
             rt,
             buffer[length..],
         ) catch |e| switch (e) {

--- a/src/root.zig
+++ b/src/root.zig
@@ -25,49 +25,54 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
                 .io = io,
                 .allocator = allocator,
                 .options = options,
-                .aios = try .initCapacity(allocator, 0),
+                .aios = try .initCapacity(
+                    allocator,
+                    0,
+                ),
             };
         }
 
-        pub fn deinit(self: *Self) void {
+        pub fn deinit(tardy: *Self) void {
             defer if (comptime builtin.os.tag == .windows)
                 AsyncIO.syscall.ws2.wsaCleanup() catch unreachable;
 
-            for (self.aios.items) |aio| self.allocator.destroy(aio);
-            self.aios.deinit(self.allocator);
+            for (tardy.aios.items) |aio| tardy.allocator.destroy(aio);
+            tardy.aios.deinit(tardy.allocator);
         }
 
         /// This will spawn a new Runtime.
-        fn spawn_runtime(self: *Self, id: usize, options: AsyncIO.Options) !Runtime {
-            self.mutex.lockUncancelable(self.io);
-            defer self.mutex.unlock(self.io);
+        fn spawn_runtime(tardy: *Self, id: usize, options: AsyncIO.Options) !Runtime {
+            tardy.mutex.lockUncancelable(tardy.io);
+            defer tardy.mutex.unlock(tardy.io);
 
             var aio: AsyncIO = blk: {
-                var io_inner = try self.allocator.create(selected_aio.Impl());
-                errdefer self.allocator.destroy(io_inner);
+                var io_inner = try tardy.allocator.create(
+                    selected_aio.Impl(),
+                );
+                errdefer tardy.allocator.destroy(io_inner);
 
-                io_inner.* = try .init(self.allocator, options);
-                errdefer io_inner.inner_deinit(self.allocator);
+                io_inner.* = try .init(tardy.allocator, options);
+                errdefer io_inner.inner_deinit(tardy.allocator);
 
-                try self.aios.append(self.allocator, io_inner);
+                try tardy.aios.append(tardy.allocator, io_inner);
                 var aio = io_inner.to_async();
 
-                const completions = try self.allocator.alloc(
+                const completions = try tardy.allocator.alloc(
                     results.Completion,
-                    self.options.size_aio_reap_max,
+                    tardy.options.size_aio_reap_max,
                 );
-                errdefer self.allocator.free(completions);
+                errdefer tardy.allocator.free(completions);
 
                 aio.attach(completions);
                 break :blk aio;
             };
-            errdefer aio.deinit(self.allocator, self.io);
+            errdefer aio.deinit(tardy.allocator, tardy.io);
 
-            return try .init(self.allocator, self.io, aio, .{
+            return try .init(tardy.allocator, tardy.io, aio, .{
                 .id = id,
-                .pooling = self.options.pooling,
-                .size_tasks_initial = self.options.size_tasks_initial,
-                .size_aio_reap_max = self.options.size_aio_reap_max,
+                .pooling = tardy.options.pooling,
+                .size_tasks_initial = tardy.options.size_tasks_initial,
+                .size_aio_reap_max = tardy.options.size_aio_reap_max,
             });
         }
 
@@ -79,11 +84,11 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
         /// exist throughout the lifetime of the runtime. It happens in an arena and is
         /// cleaned up after the runtime terminates.
         pub fn entry(
-            self: *Self,
+            tardy: *Self,
             entry_params: anytype,
             comptime entry_func: *const fn (*Runtime, @TypeOf(entry_params)) anyerror!void,
         ) !void {
-            const runtime_count: usize = switch (self.options.threading) {
+            const runtime_count: usize = switch (tardy.options.threading) {
                 .single => 1,
                 .multi => |count| count,
                 .auto => @max(try std.Thread.getCpuCount() / 2 - 1, 1),
@@ -94,11 +99,11 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
             var spawned_count: atomic.Value(usize) = .init(0);
             const spawning_count = runtime_count - 1;
 
-            var runtime = try self.spawn_runtime(0, .{
+            var runtime = try tardy.spawn_runtime(0, .{
                 .parent_async = null,
-                .pooling = self.options.pooling,
-                .size_tasks_initial = self.options.size_tasks_initial,
-                .size_aio_reap_max = self.options.size_aio_reap_max,
+                .pooling = tardy.options.pooling,
+                .size_tasks_initial = tardy.options.size_tasks_initial,
+                .size_aio_reap_max = tardy.options.size_aio_reap_max,
             });
             defer runtime.deinit();
 
@@ -106,13 +111,13 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
             log.info("thread count: {d}", .{runtime_count});
 
             var threads: std.ArrayList(std.Thread) = try .initCapacity(
-                self.allocator,
+                tardy.allocator,
                 runtime_count -| 1,
             );
             defer {
                 log.debug("waiting for the remaining threads to terminate", .{});
                 for (threads.items) |thread| thread.join();
-                threads.deinit(self.allocator);
+                threads.deinit(tardy.allocator);
             }
             // for in-spawn id assignment
             var spawn_id: atomic.Value(usize) = .init(1);
@@ -124,21 +129,20 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
                 );
                 const handle: std.Thread = try .spawn(.{}, struct {
                     fn thread_init(
-                        tardy: *Self,
-                        options: Options,
+                        tardy_: *Self,
                         parent: *AsyncIO,
                         entry_parameters: @TypeOf(entry_params),
                         count: *atomic.Value(usize),
                         total_count: usize,
                         current_id: usize,
                     ) void {
-                        var thread_rt = tardy.spawn_runtime(
+                        var thread_rt = tardy_.spawn_runtime(
                             current_id,
                             .{
                                 .parent_async = parent,
-                                .pooling = options.pooling,
-                                .size_tasks_initial = options.size_tasks_initial,
-                                .size_aio_reap_max = options.size_aio_reap_max,
+                                .pooling = tardy_.options.pooling,
+                                .size_tasks_initial = tardy_.options.size_tasks_initial,
+                                .size_aio_reap_max = tardy_.options.size_aio_reap_max,
                             },
                         ) catch |e| {
                             log.err(
@@ -173,14 +177,13 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
                         // others might be checking our running status or attempting to
                         // wake us.
                         _ = count.fetchSub(1, .acquire);
-                        while (count.load(.acquire) > 0) tardy.io.sleep(
+                        while (count.load(.acquire) > 0) tardy_.io.sleep(
                             .fromSeconds(1),
                             .awake,
                         ) catch unreachable;
                     }
                 }.thread_init, .{
-                    self,
-                    self.options,
+                    tardy,
                     &runtime.aio,
                     entry_params,
                     &spawned_count,
@@ -208,18 +211,18 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
         /// in a new Thread, allowing for more code to
         /// execute even after the runtime spawns.
         pub fn entry_in_new_thread(
-            self: *Self,
+            tardy: *Self,
             entry_params: anytype,
             comptime entry_func: *const fn (*Runtime, @TypeOf(entry_params)) anyerror!void,
         ) !void {
             const handle: std.Thread = try .spawn(.{}, struct {
-                fn entry_in_new_thread(tardy: *Self, parms: @TypeOf(entry_params)) void {
-                    tardy.entry(
+                fn entry_in_new_thread(tardy_: *Self, parms: @TypeOf(entry_params)) void {
+                    tardy_.entry(
                         parms,
                         entry_func,
                     ) catch unreachable;
                 }
-            }.entry_in_new_thread, .{ self, entry_params });
+            }.entry_in_new_thread, .{ tardy, entry_params });
             handle.detach();
         }
     };

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,6 +1,6 @@
 pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
     return struct {
-        const Self = @This();
+        const Tardy_t = @This();
         aios: std.ArrayList(inner: {
             const AioImpl = selected_aio.Impl();
             break :inner *AioImpl;
@@ -11,9 +11,11 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
         mutex: std.Io.Mutex = .init,
         options: Options,
 
-        pub fn init(allocator: mem.Allocator, io: std.Io, options: Options) !Self {
-            if (comptime builtin.os.tag == .windows)
-                AsyncIO.syscall.ws2.wsaStartup(2, 2) catch unreachable;
+        pub fn init(allocator: mem.Allocator, io: std.Io, options: Options) !Tardy_t {
+            if (comptime builtin.os.tag == .windows) AsyncIO.syscall.ws2.wsaStartup(
+                2,
+                2,
+            ) catch unreachable;
             const aio_type: AsyncIO.Kind = switch (selected_aio) {
                 .auto => AsyncIO.native(),
                 else => selected_aio,
@@ -32,7 +34,7 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
             };
         }
 
-        pub fn deinit(tardy: *Self) void {
+        pub fn deinit(tardy: *Tardy_t) void {
             defer if (comptime builtin.os.tag == .windows)
                 AsyncIO.syscall.ws2.wsaCleanup() catch unreachable;
 
@@ -41,7 +43,7 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
         }
 
         /// This will spawn a new Runtime.
-        fn spawn_runtime(tardy: *Self, id: usize, options: AsyncIO.Options) !Runtime {
+        fn spawn_runtime(tardy: *Tardy_t, id: usize, options: AsyncIO.Options) !Runtime {
             tardy.mutex.lockUncancelable(tardy.io);
             defer tardy.mutex.unlock(tardy.io);
 
@@ -84,7 +86,7 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
         /// exist throughout the lifetime of the runtime. It happens in an arena and is
         /// cleaned up after the runtime terminates.
         pub fn entry(
-            tardy: *Self,
+            tardy: *Tardy_t,
             entry_params: anytype,
             comptime entry_func: *const fn (*Runtime, @TypeOf(entry_params)) anyerror!void,
         ) !void {
@@ -129,7 +131,7 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
                 );
                 const handle: std.Thread = try .spawn(.{}, struct {
                     fn thread_init(
-                        tardy_: *Self,
+                        tardy_: *Tardy_t,
                         parent: *AsyncIO,
                         entry_parameters: @TypeOf(entry_params),
                         count: *atomic.Value(usize),
@@ -211,12 +213,12 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
         /// in a new Thread, allowing for more code to
         /// execute even after the runtime spawns.
         pub fn entry_in_new_thread(
-            tardy: *Self,
+            tardy: *Tardy_t,
             entry_params: anytype,
             comptime entry_func: *const fn (*Runtime, @TypeOf(entry_params)) anyerror!void,
         ) !void {
             const handle: std.Thread = try .spawn(.{}, struct {
-                fn entry_in_new_thread(tardy_: *Self, parms: @TypeOf(entry_params)) void {
+                fn entry_in_new_thread(tardy_: *Tardy_t, parms: @TypeOf(entry_params)) void {
                     tardy_.entry(
                         parms,
                         entry_func,

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,9 +1,9 @@
 pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
     return struct {
         const Tardy_t = @This();
-        aios: std.ArrayList(inner: {
+        aios: std.ArrayList(impl: {
             const AioImpl = selected_aio.Impl();
-            break :inner *AioImpl;
+            break :impl *AioImpl;
         }),
         // TODO: maybe make this an arena
         allocator: mem.Allocator,
@@ -48,16 +48,16 @@ pub fn Tardy(comptime selected_aio: AsyncIO.Kind) type {
             defer tardy.mutex.unlock(tardy.io);
 
             var aio: AsyncIO = blk: {
-                var io_inner = try tardy.allocator.create(
+                var io_impl = try tardy.allocator.create(
                     selected_aio.Impl(),
                 );
-                errdefer tardy.allocator.destroy(io_inner);
+                errdefer tardy.allocator.destroy(io_impl);
 
-                io_inner.* = try .init(tardy.allocator, options);
-                errdefer io_inner.inner_deinit(tardy.allocator);
+                io_impl.* = try .init(tardy.allocator, options);
+                errdefer io_impl.inner_deinit(tardy.allocator);
 
-                try tardy.aios.append(tardy.allocator, io_inner);
-                var aio = io_inner.to_async();
+                try tardy.aios.append(tardy.allocator, io_impl);
+                var aio = io_impl.to_async();
 
                 const completions = try tardy.allocator.alloc(
                     results.Completion,

--- a/src/runtime/Scheduler.zig
+++ b/src/runtime/Scheduler.zig
@@ -1,6 +1,5 @@
 pub const Scheduler = @This();
 
-allocator: mem.Allocator,
 tasks: pool.Pool(Task),
 runnable: usize,
 released: std.ArrayList(usize),
@@ -12,7 +11,7 @@ pub fn init(allocator: mem.Allocator, size: usize, pooling: pool.Kind) !Schedule
         size,
         pooling,
     );
-    errdefer tasks.deinit();
+    errdefer tasks.deinit(allocator);
 
     var released: std.ArrayList(usize) = try .initCapacity(allocator, size);
     errdefer released.deinit(allocator);
@@ -25,7 +24,6 @@ pub fn init(allocator: mem.Allocator, size: usize, pooling: pool.Kind) !Schedule
     errdefer triggers.deinit(allocator);
 
     return .{
-        .allocator = allocator,
         .tasks = tasks,
         .runnable = 0,
         .released = released,
@@ -33,73 +31,78 @@ pub fn init(allocator: mem.Allocator, size: usize, pooling: pool.Kind) !Schedule
     };
 }
 
-pub fn deinit(sched: *Scheduler, io: std.Io) void {
+pub fn deinit(sched: *Scheduler, allocator: mem.Allocator, io: std.Io) void {
     var iter = sched.tasks.iterator();
     while (iter.next_ptr()) |task| {
-        task.frame.deinit(sched.allocator);
+        task.frame.deinit(allocator);
     }
-    sched.tasks.deinit();
-    sched.released.deinit(sched.allocator);
-    sched.triggers.deinit(sched.allocator, io);
+    sched.tasks.deinit(allocator);
+    sched.released.deinit(allocator);
+    sched.triggers.deinit(allocator, io);
 }
 
-pub fn set_runnable(self: *Scheduler, index: usize) void {
-    const task = self.tasks.get_ptr(index);
+pub fn set_runnable(sched: *Scheduler, index: usize) void {
+    const task = sched.tasks.get_ptr(index);
     debug.assert(task.state != .runnable);
     task.state = .runnable;
-    self.runnable += 1;
+    sched.runnable += 1;
 }
 
-pub fn trigger_await(self: *Scheduler) void {
-    const rt: *Runtime = @fieldParentPtr("scheduler", self);
+pub fn trigger_await(sched: *Scheduler) void {
+    const rt: *Runtime = @fieldParentPtr("scheduler", sched);
     const index = rt.current_task.?;
-    const task = self.tasks.get_ptr(index);
+    const task = sched.tasks.get_ptr(index);
 
     // To waiting...
     task.state = .wait_for_trigger;
-    self.runnable -= 1;
+    sched.runnable -= 1;
 
     Coroutine.yield();
 }
 
 // NOTE: This can spuriously trigger a Task later in the Run Loop.
 /// Safe to call from a different Runtime.
-pub fn trigger(self: *Scheduler, index: usize) !void {
-    const rt: *Runtime = @fieldParentPtr("scheduler", self);
-    try self.triggers.set(rt.io, index);
+pub fn trigger(sched: *Scheduler, index: usize) !void {
+    const rt: *Runtime = @fieldParentPtr("scheduler", sched);
+    try sched.triggers.set(rt.io, index);
 }
 
 // This is only safe to call from the Runtime that the Frame is running on.
-pub fn io_await(self: *Scheduler, job: AsyncIO.Submission) !void {
-    const rt: *Runtime = @fieldParentPtr("scheduler", self);
+pub fn io_await(
+    sched: *Scheduler,
+    allocator: mem.Allocator,
+    job: AsyncIO.Submission,
+) !void {
+    const rt: *Runtime = @fieldParentPtr("scheduler", sched);
     const index = rt.current_task.?;
-    const task = self.tasks.get_ptr(index);
+    const task = sched.tasks.get_ptr(index);
 
     // To waiting...
     task.state = .wait_for_io;
-    self.runnable -= 1;
+    sched.runnable -= 1;
 
     // Queue the related I/O job.
-    try rt.aio.queue_job(index, job);
+    try rt.aio.queue_job(allocator, index, job);
     Coroutine.yield();
 }
 
 pub fn spawn(
-    self: *Scheduler,
+    sched: *Scheduler,
+    allocator: mem.Allocator,
     comptime coroutine_fn: anytype,
     args: anytype,
     stack_size: ?Coroutine.Stack,
 ) !void {
     const index = blk: {
-        if (self.released.pop()) |index| {
-            break :blk self.tasks.borrow_assume_unset(index);
+        if (sched.released.pop()) |index| {
+            break :blk sched.tasks.borrow_assume_unset(index);
         } else {
-            break :blk try self.tasks.borrow();
+            break :blk try sched.tasks.borrow(allocator);
         }
     };
 
     const frame: *Coroutine = .init(
-        self.allocator,
+        allocator,
         coroutine_fn,
         args,
         stack_size,
@@ -110,20 +113,20 @@ pub fn spawn(
         .frame = frame,
         .state = .dead,
     };
-    const item_ptr = self.tasks.get_ptr(index);
+    const item_ptr = sched.tasks.get_ptr(index);
     item_ptr.* = item;
-    self.set_runnable(index);
+    sched.set_runnable(index);
 }
 
-pub fn release(self: *Scheduler, index: usize) !void {
+pub fn release(sched: *Scheduler, allocator: mem.Allocator, index: usize) !void {
     // must be runnable to set?
-    const task = self.tasks.get_ptr(index);
+    const task = sched.tasks.get_ptr(index);
     debug.assert(task.state == .runnable);
     task.state = .dead;
-    self.runnable -= 1;
+    sched.runnable -= 1;
 
-    self.tasks.release(index);
-    try self.released.append(self.allocator, index);
+    sched.tasks.release(index);
+    try sched.released.append(allocator, index);
 }
 
 const TaskWithJob = struct {

--- a/src/runtime/Scheduler.zig
+++ b/src/runtime/Scheduler.zig
@@ -64,7 +64,7 @@ pub fn trigger_await(sched: *Scheduler) void {
 /// Safe to call from a different Runtime.
 pub fn trigger(sched: *Scheduler, index: usize) !void {
     const rt: *Runtime = @fieldParentPtr("scheduler", sched);
-    try sched.triggers.set(rt.io, index);
+    try sched.triggers.set(rt.allocator, rt.io, index);
 }
 
 // This is only safe to call from the Runtime that the Frame is running on.

--- a/src/runtime/Storage.zig
+++ b/src/runtime/Storage.zig
@@ -1,6 +1,7 @@
 /// Storage is deleteless and clobberless.
 pub const Storage = @This();
 
+// TODO: only store the state
 arena: std.heap.ArenaAllocator,
 map: std.StringHashMapUnmanaged(*anyopaque),
 
@@ -11,55 +12,64 @@ pub fn init(allocator: std.mem.Allocator) Storage {
     };
 }
 
-pub fn deinit(self: *Storage) void {
-    self.arena.deinit();
+pub fn deinit(storage: *Storage) void {
+    storage.arena.deinit();
 }
 
 /// Store a pointer that is not managed.
 /// This will NOT CLONE the item.
 /// This asserts that no other item has the same name.
-pub fn store_ptr(self: *Storage, name: []const u8, item: anytype) !void {
+pub fn store_ptr(storage: *Storage, name: []const u8, item: anytype) !void {
     debug.assert(@typeInfo(@TypeOf(item)) == .Pointer);
-    try self.map.putNoClobber(
-        self.arena.allocator(),
+    try storage.map.putNoClobber(
+        storage.arena.allocator(),
         name,
         @ptrCast(item),
     );
 }
 
-pub fn store_alloc_ret(self: *Storage, name: []const u8, item: anytype) !*@TypeOf(item) {
-    const allocator = self.arena.allocator();
+pub fn store_alloc_ret(
+    storage: *Storage,
+    name: []const u8,
+    item: anytype,
+) !*@TypeOf(item) {
+    const allocator = storage.arena.allocator();
     const clone = try allocator.create(@TypeOf(item));
     errdefer allocator.destroy(clone);
+
     clone.* = item;
-    try self.map.putNoClobber(allocator, name, @ptrCast(clone));
+    try storage.map.putNoClobber(
+        allocator,
+        name,
+        @ptrCast(clone),
+    );
     return clone;
 }
 
 /// Store a new item in the Storage.
 /// This will CLONE (allocate) the item that you pass in and manage the clone.
 /// This asserts that no other item has the same name.
-pub fn store_alloc(self: *Storage, name: []const u8, item: anytype) !void {
-    _ = try self.store_alloc_ret(name, item);
+pub fn store_alloc(storage: *Storage, name: []const u8, item: anytype) !void {
+    _ = try storage.store_alloc_ret(name, item);
 }
 
 /// Get an item that is within the Storage.
 /// This asserts that the item you are looking for exists.
-pub fn get(self: *Storage, name: []const u8, comptime T: type) T {
-    return self.get_ptr(name, T).*;
+pub fn get(storage: *Storage, name: []const u8, comptime T: type) T {
+    return storage.get_ptr(name, T).*;
 }
 
 /// Get a const (immutable) pointer to an item that is within the Storage.
 /// This asserts that the item you are looking for exists.
-pub fn get_const_ptr(self: *Storage, name: []const u8, comptime T: type) *const T {
-    const got = self.map.get(name).?;
+pub fn get_const_ptr(storage: *Storage, name: []const u8, comptime T: type) *const T {
+    const got = storage.map.get(name).?;
     return @ptrCast(@alignCast(got));
 }
 
 /// Get a (mutable) pointer to an item that is within the Storage.
 /// This asserts that the item you are looking for exists.
-pub fn get_ptr(self: *Storage, name: []const u8, comptime T: type) *T {
-    const got = self.map.get(name).?;
+pub fn get_ptr(storage: *Storage, name: []const u8, comptime T: type) *T {
+    const got = storage.map.get(name).?;
     return @ptrCast(@alignCast(got));
 }
 
@@ -81,8 +91,14 @@ test "Storage Storing" {
     value_ptr.* += 100;
 
     try testing.expectEqual(byte, storage.get("byte", u8));
-    try testing.expectEqual(index, storage.get("index", usize));
-    try testing.expectEqual(value + 100, storage.get("value", u32));
+    try testing.expectEqual(
+        index,
+        storage.get("index", usize),
+    );
+    try testing.expectEqual(
+        value + 100,
+        storage.get("value", u32),
+    );
 }
 
 const std = @import("std");

--- a/src/runtime/Timer.zig
+++ b/src/runtime/Timer.zig
@@ -1,7 +1,9 @@
 pub const Timer = @This();
 
 pub fn delay(rt: *Runtime, duration: std.Io.Duration) !void {
-    try rt.scheduler.io_await(.{ .timer = duration });
+    try rt.scheduler.io_await(rt.allocator, .{
+        .timer = duration,
+    });
 }
 
 const std = @import("std");

--- a/test/e2e/FileChain.zig
+++ b/test/e2e/FileChain.zig
@@ -64,8 +64,8 @@ pub fn init(
 
     const path_dupe = try path.dupe(allocator);
     errdefer switch (path_dupe) {
-        .rel => |inner| allocator.free(inner.path),
-        .abs => |p| allocator.free(p),
+        .rel => |rel| allocator.free(rel.path),
+        .abs => |abs| allocator.free(abs),
     };
 
     debug.assert(validate_chain(chain));
@@ -84,8 +84,8 @@ pub fn deinit(file_chain: *FileChain, allocator: mem.Allocator) void {
     defer allocator.free(file_chain.steps);
     defer allocator.free(file_chain.buffer);
     defer switch (file_chain.path) {
-        .rel => |inner| allocator.free(inner.path),
-        .abs => |p| allocator.free(p),
+        .rel => |rel| allocator.free(rel.path),
+        .abs => |abs| allocator.free(abs),
     };
 }
 

--- a/test/e2e/FileChain.zig
+++ b/test/e2e/FileChain.zig
@@ -28,7 +28,7 @@ pub fn validate_chain(chain: []const Step) bool {
     return true;
 }
 
-pub fn generate_random_chain(allocator: std.mem.Allocator, seed: u64) ![]Step {
+pub fn generate_random_chain(allocator: mem.Allocator, seed: u64) ![]Step {
     var prng: std.Random.DefaultPrng = .init(seed);
     const rand = prng.random();
 
@@ -52,7 +52,7 @@ pub fn generate_random_chain(allocator: std.mem.Allocator, seed: u64) ![]Step {
 
 // Path is expected to remain valid.
 pub fn init(
-    allocator: std.mem.Allocator,
+    allocator: mem.Allocator,
     chain: []const Step,
     path: fs.Path,
     buffer_size: usize,
@@ -80,10 +80,10 @@ pub fn init(
     };
 }
 
-pub fn deinit(self: *FileChain, allocator: std.mem.Allocator) void {
-    defer allocator.free(self.steps);
-    defer allocator.free(self.buffer);
-    defer switch (self.path) {
+pub fn deinit(file_chain: *FileChain, allocator: mem.Allocator) void {
+    defer allocator.free(file_chain.steps);
+    defer allocator.free(file_chain.buffer);
+    defer switch (file_chain.path) {
         .rel => |inner| allocator.free(inner.path),
         .abs => |p| allocator.free(p),
     };
@@ -216,11 +216,15 @@ test "FileChain: Verify Double Close" {
 test "FileChain: Validate Random Chain" {
     // Actually generates and tests a random FileChain :)
     var seed: u64 = undefined;
-    try std.posix.getrandom(std.mem.asBytes(&seed));
+    try std.posix.getrandom(mem.asBytes(&seed));
     errdefer std.debug.print("failed seed: {d}\n", .{seed});
 
-    const chain = try FileChain.generate_random_chain(testing.allocator, seed);
+    const chain = try FileChain.generate_random_chain(
+        testing.allocator,
+        seed,
+    );
     defer testing.allocator.free(chain);
+
     try testing.expect(FileChain.validate_chain(chain));
 }
 
@@ -237,6 +241,7 @@ const Step = enum {
 };
 
 const std = @import("std");
+const mem = std.mem;
 const debug = std.debug;
 const testing = std.testing;
 

--- a/test/e2e/main.zig
+++ b/test/e2e/main.zig
@@ -15,16 +15,24 @@ pub fn main(init: std.process.Init) !void {
     var maybe_seed_buffer: [21]u8 = undefined;
     const seed_string = args.next() orelse blk: {
         var stdin_r = Io.File.stdin().reader(io, &.{});
-        const bytes = try stdin_r.interface.allocRemaining(gpa, .limited(max_stderr_output));
+        const bytes = try stdin_r.interface.allocRemaining(
+            gpa,
+            .limited(max_stderr_output),
+        );
         defer gpa.free(bytes);
 
-        var iter = mem.splitScalar(u8, bytes, '\n');
+        var iter = mem.splitScalar(
+            u8,
+            bytes,
+            '\n',
+        );
         const not_passed_in = "seed not passed in: ./e2e [seed]";
         const pre_new = iter.next() orelse @panic(not_passed_in);
         const length = pre_new.len;
 
         if (length <= 1) @panic(not_passed_in);
-        if (length >= maybe_seed_buffer.len) @panic("seed too long to be a u64");
+        if (length >= maybe_seed_buffer.len)
+            @panic("seed too long to be a u64");
 
         debug.assert(length < maybe_seed_buffer.len);
         @memcpy(maybe_seed_buffer[0..length], pre_new);
@@ -32,7 +40,9 @@ pub fn main(init: std.process.Init) !void {
         break :blk maybe_seed_buffer[0..length :0];
     };
 
-    const seed = std.fmt.parseUnsigned(u64, seed_string, 10) catch @panic("seed passed in is not u64");
+    const seed = std.fmt.parseUnsigned(u64, seed_string, 10) catch
+        @panic("seed passed in is not u64");
+
     var prng: std.Random.DefaultPrng = .init(seed);
     const rand = prng.random();
 
@@ -58,7 +68,7 @@ pub fn main(init: std.process.Init) !void {
     defer td.deinit();
 
     const EntryParams = struct {
-        runtime: ?*Runtime,
+        runtime: ?*tardy.Runtime,
         shared: *const e2e.Params,
     };
 
@@ -70,7 +80,7 @@ pub fn main(init: std.process.Init) !void {
     try td.entry(
         &params,
         struct {
-            fn start(rt: *Runtime, p: *EntryParams) !void {
+            fn start(rt: *tardy.Runtime, p: *EntryParams) !void {
                 switch (rt.id) {
                     0 => {
                         p.runtime = rt;
@@ -79,9 +89,17 @@ pub fn main(init: std.process.Init) !void {
                             .{ rt, p.shared },
                             if (is_unix) .KiB(28) else .MiB(2),
                         );
-                        try rt.spawn(second.start_frame, .{ rt, p.shared }, .@"32KiB");
+                        try rt.spawn(
+                            second.start_frame,
+                            .{ rt, p.shared },
+                            .@"32KiB",
+                        );
                     },
-                    1 => try rt.spawn(timeout_task, .{ rt, &p.runtime }, .@"32KiB"),
+                    1 => try rt.spawn(
+                        timeout_task,
+                        .{ rt, &p.runtime },
+                        .@"32KiB",
+                    ),
                     else => unreachable,
                 }
             }
@@ -91,12 +109,15 @@ pub fn main(init: std.process.Init) !void {
     log.info("seed={d} passed", .{seed});
 }
 
-fn timeout_task(rt: *Runtime, other: *const ?*Runtime) !void {
-    const TIMEOUT_LENGTH_S = std.time.s_per_min;
+fn timeout_task(rt: *tardy.Runtime, other: *const ?*tardy.Runtime) !void {
+    const timeout_length_s = std.time.s_per_min;
 
     // Checks every second to see if the other Runtime is done.
-    for (0..TIMEOUT_LENGTH_S) |_| {
-        try Timer.delay(rt, .{ .nanoseconds = 1 * std.time.ns_per_s });
+    for (0..timeout_length_s) |_| {
+        try Timer.delay(
+            rt,
+            .{ .nanoseconds = 1 * std.time.ns_per_s },
+        );
         if (other.*) |o| if (!o.running) break;
     }
 
@@ -120,10 +141,7 @@ const builtin = @import("builtin");
 const options = @import("options");
 const tardy = @import("tardy");
 const AsyncIO = tardy.AsyncIO;
-const Dir = tardy.fs.Dir;
-const Runtime = tardy.Runtime;
-const Task = Runtime.Task;
-const Timer = Runtime.Timer;
+const Timer = tardy.Runtime.Timer;
 
 const e2e = @import("e2e.zig");
 const first = @import("first.zig");

--- a/test/e2e/second.zig
+++ b/test/e2e/second.zig
@@ -33,7 +33,7 @@ pub fn start_frame(rt: *Runtime, shared_params: *const e2e.Params) !void {
     errdefer rt.allocator.destroy(client_chain_ptr);
 
     server_chain_ptr.* = try .init(rt.allocator, chain, 4096);
-    client_chain_ptr.* = try server_chain_ptr.derive_client_chain();
+    client_chain_ptr.* = try server_chain_ptr.derive_client_chain(rt.allocator);
 
     try rt.spawn(
         Client.chain_frame,

--- a/test/e2e/tcp_chain.zig
+++ b/test/e2e/tcp_chain.zig
@@ -1,5 +1,4 @@
 pub const Server = struct {
-    allocator: mem.Allocator,
     socket: ?net.Socket = null,
     steps: []Step,
     index: usize = 0,
@@ -21,15 +20,14 @@ pub const Server = struct {
         errdefer allocator.free(buffer);
 
         return .{
-            .allocator = allocator,
             .steps = chain_dupe,
             .buffer = buffer,
         };
     }
 
-    pub fn deinit(self: *const Server) void {
-        defer self.allocator.free(self.steps);
-        defer self.allocator.free(self.buffer);
+    pub fn deinit(server: *const Server, allocator: mem.Allocator) void {
+        defer allocator.free(server.steps);
+        defer allocator.free(server.buffer);
     }
 
     pub fn next_steps(current: Step) []const Step {
@@ -75,16 +73,16 @@ pub const Server = struct {
         return try list.toOwnedSlice(allocator);
     }
 
-    pub fn derive_client_chain(self: *const Server) !Client {
-        debug.assert(self.steps.len > 0);
+    pub fn derive_client_chain(server: *const Server, allocator: mem.Allocator) !Client {
+        debug.assert(server.steps.len > 0);
 
-        const client_steps = try self.allocator.alloc(
+        const client_steps = try allocator.alloc(
             Client.Step,
-            self.steps.len,
+            server.steps.len,
         );
-        errdefer self.allocator.free(client_steps);
+        errdefer allocator.free(client_steps);
 
-        for (self.steps, 0..) |step, i| {
+        for (server.steps, 0..) |step, i| {
             switch (step) {
                 .accept => client_steps[i] = .connect,
                 .recv => client_steps[i] = .send,
@@ -93,11 +91,10 @@ pub const Server = struct {
             }
         }
 
-        const buffer = try self.allocator.alloc(u8, self.buffer.len);
-        errdefer self.allocator.free(buffer);
+        const buffer = try allocator.alloc(u8, server.buffer.len);
+        errdefer allocator.free(buffer);
 
         return .{
-            .allocator = self.allocator,
             .steps = client_steps,
             .buffer = buffer,
         };
@@ -110,7 +107,7 @@ pub const Server = struct {
         server_socket: net.Socket,
     ) !void {
         defer rt.allocator.destroy(chain);
-        defer chain.deinit();
+        defer chain.deinit(rt.allocator);
         errdefer unreachable;
 
         chain: while (chain.index < chain.steps.len) : (chain.index += 1) {
@@ -156,19 +153,18 @@ pub const Server = struct {
 };
 
 pub const Client = struct {
-    allocator: mem.Allocator,
     steps: []Step,
     index: usize = 0,
     buffer: []u8,
 
-    pub fn deinit(self: *const Client) void {
-        defer self.allocator.free(self.steps);
-        defer self.allocator.free(self.buffer);
+    pub fn deinit(client: *const Client, allocator: mem.Allocator) void {
+        defer allocator.free(client.steps);
+        defer allocator.free(client.buffer);
     }
 
     pub fn chain_frame(chain: *Client, rt: *Runtime, counter: *usize, port: u16) !void {
         defer rt.allocator.destroy(chain);
-        defer chain.deinit();
+        defer chain.deinit(rt.allocator);
         errdefer unreachable;
 
         var socket: net.Socket = try .init(rt.io, .{


### PR DESCRIPTION
This is part of the effort to make it obvious to see tardy's allocation patterns and squash some reported memory issues in Zzz.